### PR TITLE
remove a format code from a verbatim block

### DIFF
--- a/lib/Mail/DMARC.pm
+++ b/lib/Mail/DMARC.pm
@@ -232,7 +232,9 @@ sub {}  # for vim automatic code folding
 
 DMARC: Domain-based Message Authentication, Reporting and Conformance
 
-  my $dmarc = Mail::DMARC::PurePerl->new( see L<new|#new> for required args );
+  my $dmarc = Mail::DMARC::PurePerl->new(
+    ... # see the documentation for the "new" method for required args
+  );
 
   my $result = $dmarc->validate();
 


### PR DESCRIPTION
This just removes a Pod `L<...>` sequence from the synopsis.  The synopsis code is in a "verbatim paragraph," where nothing will render the `L<...>`, so it looks lousy on the web.
