### PR TITLE
Ignore DomainKeys signatures

### DIFF
--- a/lib/Mail/DMARC.pm
+++ b/lib/Mail/DMARC.pm
@@ -86,6 +86,7 @@ sub dkim_from_mail_dkim {
 
     # A DKIM verifier will have result and signature methods.
     foreach my $s ( $dkim->signatures ) {
+        next if ref $s eq 'Mail::DKIM::DkSignature';
         push @{ $self->{dkim} },
             {
             domain       => $s->domain,


### PR DESCRIPTION
DomainKeys signatures can be evaluated by Mail::DKIM but should not be considered by DMARC, skip them if found in a dkim_from_mail_dkim call.
