### PR TITLE
Show "new record" output only in verbose mode.

### DIFF
--- a/lib/Mail/DMARC/Report/Store/SQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL.pm
@@ -440,7 +440,7 @@ sub row_exists {
     my ($self, $rid, $rec ) = @_;
 
     if ( ! defined $rec->{row}{count} ) {
-        carp "\tnew record";
+        print "new record\n" if $self->verbose;
         return;
     };
 


### PR DESCRIPTION
I feel that the "new record" output shouldn't be a carp, but should be a print if verbose.
It is informational, not an error.