### PR TITLE
fix wrong name for Mail::DMARC::opendmarc

### DIFF
--- a/lib/Mail/DMARC.pm
+++ b/lib/Mail/DMARC.pm
@@ -342,7 +342,7 @@ L<Mail::DMARC::Report::View> - CLI and CGI methods for viewing reports
 
 =back
 
-L<Mail::DMARC::libopendmarc|http://search.cpan.org/~shari/Mail-DMARC-opendmarc> - an XS implementation using libopendmarc
+L<Mail::DMARC::opendmarc|http://search.cpan.org/~shari/Mail-DMARC-opendmarc> - an XS implementation using libopendmarc
 
 =head1 METHODS
 


### PR DESCRIPTION
the module is Mail::DMARC::opendmarc, not Mail::DMARC::**lib**opendmarc