### PR TITLE
fix precedence on return-or-croak

### DIFF
--- a/lib/Mail/DMARC/Base.pm
+++ b/lib/Mail/DMARC/Base.pm
@@ -79,11 +79,11 @@ sub any_inet_pton {
 
     if ( $ip_txt =~ /:/ ) {
         return Socket6::inet_pton( AF_INET6, $ip_txt )
-            or croak "invalid IPv6: $ip_txt";
+            || croak "invalid IPv6: $ip_txt";
     }
 
     return Socket6::inet_pton( AF_INET, $ip_txt )
-        or croak "invalid IPv4: $ip_txt";
+        || croak "invalid IPv4: $ip_txt";
 }
 
 sub is_public_suffix {

--- a/lib/Mail/DMARC/Report/Store/SQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL.pm
@@ -582,7 +582,7 @@ EO_RPP
     return $self->query( $query,
         [ $id, @$pub{ qw/ adkim aspf p sp pct rua /} ]
     )
-    or croak "failed to insert published policy";
+    || croak "failed to insert published policy";
 }
 
 sub db_connect {


### PR DESCRIPTION
return does not have a return value, so the "or" side of these
return-or-croak is never ever evaluated, and return just returns
false;  the || operator is needed

(detected by a warning added in perl v5.20)