### PR TITLE
use Test::File::ShareDir to allow testing without blib

### DIFF
--- a/t/00.Dmarc.t
+++ b/t/00.Dmarc.t
@@ -3,6 +3,9 @@ use warnings;
 
 use Test::More;
 
+use Test::File::ShareDir
+  -share => { -dist => { 'Mail-DMARC' => 'share' } };
+
 use lib 'lib';
 
 use_ok('Mail::DMARC');

--- a/t/03.Base.t
+++ b/t/03.Base.t
@@ -4,6 +4,9 @@ use warnings;
 use Data::Dumper;
 use Test::More;
 
+use Test::File::ShareDir
+  -share => { -dist => { 'Mail-DMARC' => 'share' } };
+
 use lib 'lib';
 
 my $mod = 'Mail::DMARC::Base';

--- a/t/04.PurePerl.t
+++ b/t/04.PurePerl.t
@@ -5,6 +5,9 @@ use Data::Dumper;
 use Test::More;
 use URI;
 
+use Test::File::ShareDir
+  -share => { -dist => { 'Mail-DMARC' => 'share' } };
+
 use lib 'lib';
 use_ok('Mail::DMARC::PurePerl');
 

--- a/t/06.Result.t
+++ b/t/06.Result.t
@@ -4,6 +4,9 @@ use warnings;
 use Data::Dumper;
 use Test::More;
 
+use Test::File::ShareDir
+  -share => { -dist => { 'Mail-DMARC' => 'share' } };
+
 use lib 'lib';
 use_ok('Mail::DMARC::PurePerl');
 use_ok('Mail::DMARC::Result');

--- a/t/09.HTTP.t
+++ b/t/09.HTTP.t
@@ -5,6 +5,9 @@ use CGI;
 use Data::Dumper;
 use Test::More;
 
+use Test::File::ShareDir
+  -share => { -dist => { 'Mail-DMARC' => 'share' } };
+
 use lib 'lib';
 
 foreach my $req ( 'DBD::SQLite 1.31', 'Net::Server::HTTP' ) {

--- a/t/11.Report.Store.t
+++ b/t/11.Report.Store.t
@@ -4,6 +4,9 @@ use warnings;
 use Data::Dumper;
 use Test::More;
 
+use Test::File::ShareDir
+  -share => { -dist => { 'Mail-DMARC' => 'share' } };
+
 use lib 'lib';
 
 eval "use DBD::SQLite 1.31";


### PR DESCRIPTION
If tests rely on files in sharedir, then "prove -l t" will not test
the checkout of the distribution from git.

Test::File::ShareDir, as used here, lets "./share" hold the files
for the dist Mail-DMARC, and prove without a built works again.