### PR TITLE
allow for spf and dkim to be resolved lazily

### DIFF
--- a/lib/Mail/DMARC.pm
+++ b/lib/Mail/DMARC.pm
@@ -59,9 +59,12 @@ sub _unwrap {
 sub dkim {
     my ( $self, @args ) = @_;
 
-    $self->is_valid_dkim if $self->_unwrap( \$self->{dkim} );
+    if (0 == scalar @args) {
+      $self->is_valid_dkim if $self->_unwrap( \$self->{dkim} );
+      return $self->{dkim};
+    }
 
-    return $self->{dkim} if 0 == scalar @args;
+    $self->{dkim} ||= [];
 
     if ( scalar @args > 1 ) {
         croak "invalid arguments to dkim" if @args % 2;
@@ -123,9 +126,12 @@ sub dkim_from_mail_dkim {
 sub spf {
     my ( $self, @args ) = @_;
 
-    $self->is_valid_spf if $self->_unwrap( \$self->{spf} );
+    if (0 == scalar @args) {
+      $self->is_valid_spf if $self->_unwrap( \$self->{spf} );
+      return $self->{spf}
+    }
 
-    return $self->{spf} if 0 == scalar @args;
+    $self->{spf} ||= [];
 
     if ( scalar @args == 1 && ref $args[0] ) {
         if ( ref $args[0] eq 'HASH' ) {

--- a/t/00.Dmarc.t
+++ b/t/00.Dmarc.t
@@ -65,6 +65,16 @@ sub test_dkim {
     ok( $dmarc->dkim([ \%test_dkim, \%test_dkim ]), "dkim, arrayref set" );
     is_deeply($dmarc->dkim, [ \%test_dkim, \%test_dkim ], "dkim, arrayref set result");
 
+# set with a callback
+    $dmarc->{dkim} = undef;
+    my $counter  = 0;
+    my $callback = sub { $counter++; [ \%test_dkim ] };
+    ok( $dmarc->dkim($callback), "dkim, arrayref set" );
+    is($counter, 0, "callback not yet called");
+    is_deeply($dmarc->dkim, [ \%test_dkim ], "dkim, callback-derived result");
+    is_deeply($dmarc->dkim, [ \%test_dkim ], "dkim, callback-cached result");
+    is($counter, 1, "callback exactly once");
+
 # set DKIM with invalid key=>val pairs
     eval { $dmarc->dkim( dom => 'foo', 'blah' ) };
     chomp $@;
@@ -96,6 +106,16 @@ sub test_spf {
     $dmarc->{spf} = undef;
     ok( $dmarc->spf([ \%test_spf, \%test_spf ]), "spf, arrayref set" );
     is_deeply($dmarc->spf, [ \%test_spf, \%test_spf ], "spf, arrayref set result");
+
+# set with a callback
+    $dmarc->{spf} = undef;
+    my $counter  = 0;
+    my $callback = sub { $counter++; [ \%test_spf ] };
+    ok( $dmarc->spf($callback), "spf, arrayref set" );
+    is($counter, 0, "callback not yet called");
+    is_deeply($dmarc->spf, [ \%test_spf ], "spf, callback-derived result");
+    is_deeply($dmarc->spf, [ \%test_spf ], "spf, callback-cached result");
+    is($counter, 1, "callback exactly once");
 
 # set SPF with invalid key=>val pairs
     eval { $dmarc->spf( dom => 'foo', 'blah' ) };


### PR DESCRIPTION
This addresses #26.

With this patch series, spf and dkim setters can be given coderefs which will be resolved once (and only once) when read, but not when clobbered.  I do not believe any further change is needed, since is_X_aligned are only called after a DMARC policy can be resolved.