### PR TITLE
Fix dkim invalid result.

### DIFF
--- a/lib/Mail/DMARC.pm
+++ b/lib/Mail/DMARC.pm
@@ -88,15 +88,17 @@ sub dkim_from_mail_dkim {
     foreach my $s ( $dkim->signatures ) {
         next if ref $s eq 'Mail::DKIM::DkSignature';
 
-        if ($s->{result} eq 'invalid') {  # See GH Issue #21
-            $s->{result} = 'temperror';
+        my $result = $s->result;
+
+        if ($result eq 'invalid') {  # See GH Issue #21
+            $result = 'temperror';
         }
 
         push @{ $self->{dkim} },
             {
             domain       => $s->domain,
             selector     => $s->selector,
-            result       => $s->result,
+            result       => $result,
             human_result => $s->result_detail,
             };
     }


### PR DESCRIPTION
Seems that fix didn't work, I was getting lots of "Use of uninitialized value in string eq at /usr/local/share/perl/5.14.2/Mail/DMARC.pm line 91." errors.

The internal for this is not $s->{'result'}, pull it and then check and modify the local copy to avoid poking around in internals.
