### PR TITLE
Do not check return value of policy insert query

### DIFF
--- a/lib/Mail/DMARC/Report/Store/SQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL.pm
@@ -579,10 +579,10 @@ INSERT INTO report_policy_published
 VALUES (??)
 EO_RPP
     ;
-    return $self->query( $query,
+    $self->query( $query,
         [ $id, @$pub{ qw/ adkim aspf p sp pct rua /} ]
-    )
-    || croak "failed to insert published policy";
+    );
+    return;
 }
 
 sub db_connect {

--- a/lib/Mail/DMARC/Report/Store/SQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL.pm
@@ -582,7 +582,7 @@ EO_RPP
     $self->query( $query,
         [ $id, @$pub{ qw/ adkim aspf p sp pct rua /} ]
     );
-    return;
+    return 1;
 }
 
 sub db_connect {


### PR DESCRIPTION
I am seeing this error quite a lot when creating new reports...

failed to insert published policy at /usr/local/share/perl/5.14.2/Mail/DMARC/Report.pm line 77.

However, the policy row does seem to be inserted correctly.

It seems that the last insert id is zero as that table does not have an auto increment field, and that is triggering the croak in insert_policy_published(), and the fix would be to remote both the croak, and the return, as its value isn't used anywhere.