### PR TITLE
don't mandate SPF results conform to XML schema

### DIFF
--- a/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/SPF.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/SPF.pm
@@ -75,11 +75,13 @@ sub is_valid {
 
     foreach my $f (qw/ domain result scope /) {
         next if $self->{$f};
-        croak "SPF $f is required!";
+        warn "SPF $f is required!\n";
+        return 0;
     }
 
     if ( $self->{result} =~ /^pass$/i && !$self->{domain} ) {
-        croak "SPF pass MUST include the RFC5321.MailFrom domain!";
+        warn "SPF pass MUST include the RFC5321.MailFrom domain!\n";
+        return 0;
     }
 
     return 1;


### PR DESCRIPTION
because many received reports do not. Instead, throw warnings.

A disadvantage of using the same code paths is that now we have a little problem with the "be strict about what you send and liberal about what you receive" doctrine. Reports coming in off the wire don't necessarily conform (example: Google doesn't include scope in SPF results) but we certainly don't want to reject them. This PR changes the croaks to warnings, and now it's up to the caller to a) do nothing or b) call $spf->is_valid and then c) Do The Right Thing.

It would seem that somewhere around the save_aggregate function an ->is_valid check is required.

