### PR TITLE
restore callbacks after the merge of oh-no

### DIFF
--- a/lib/Mail/DMARC.pm
+++ b/lib/Mail/DMARC.pm
@@ -71,7 +71,15 @@ sub local_policy {
 
 sub dkim {
     my ($self, @args) = @_;
-    return $self->{dkim} if 0 == scalar @args;
+
+    if (0 == scalar @args) {
+      $self->_unwrap('dkim');
+      return $self->{dkim};
+    }
+
+    if (1 == scalar @args && ref $args[0] eq 'CODE') {
+      return $self->{dkim} = $args[0];
+    }
 
     # one shot
     if (1 == scalar @args && ref $args[0] eq 'ARRAY') {
@@ -89,9 +97,25 @@ sub dkim {
     return $self->{dkim};
 }
 
+sub _unwrap {
+    my ( $self, $key ) = @_;
+    if ($self->{$key} and ref $self->{$key} eq 'CODE') {
+        my $code = delete $self->{$key};
+        $self->$key( $self->$code );
+    }
+    return;
+}
+
 sub spf {
    my ($self, @args) = @_;
-    return $self->{spf} if 0 == scalar @args;
+    if (0 == scalar @args) {
+      $self->_unwrap('spf');
+      return $self->{spf};
+    }
+
+    if (1 == scalar @args && ref $args[0] eq 'CODE') {
+      return $self->{spf} = $args[0];
+    }
 
     if (1 == scalar @args && ref $args[0] eq 'ARRAY') {
         # warn "SPF one shot";

--- a/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/DKIM.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/DKIM.pm
@@ -9,8 +9,6 @@ sub new {
 
     my $self = bless {}, $class;
 
-    #$self->is_valid if $self->_unwrap( \$self->{dkim} );
-
     # a bare hash
     return $self->_from_hash(@args) if scalar @args > 1;
 
@@ -24,11 +22,6 @@ sub new {
     };
 
     return $self->_from_hashref($dkim) if 'HASH' eq ref $dkim;
-
-    if ( 'CODE' eq ref $dkim ) {
-        $self->{dkim} = $dkim;
-        return $self->{dkim}; # <-- may confuse people not thinking straight
-    };
 
     croak "invalid dkim argument";
 }
@@ -68,15 +61,6 @@ sub _from_hash {
 
 sub _from_hashref {
     return $_[0]->_from_hash(%{ $_[1] });
-}
-
-sub _unwrap {
-    my ( $self, $ref ) = @_;
-    if (ref $$ref and ref $$ref eq 'CODE') {
-        $$ref = $$ref->();
-        return 1;
-    }
-    return;
 }
 
 sub is_valid {

--- a/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/SPF.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/SPF.pm
@@ -11,7 +11,6 @@ sub new {
     my $self = bless {}, $class;
 
     if (0 == scalar @args) {
-        $self->is_valid if $self->_unwrap( \$self->{callback} );
         return $self;
     }
 
@@ -22,7 +21,8 @@ sub new {
     return $spf if ref $spf eq $class;
 
     return $self->_from_hashref($spf) if 'HASH' eq ref $spf;
-    return $self->_from_callback($spf) if 'CODE' eq ref $spf;
+
+    croak "invalid spf argument";
 }
 
 sub domain {
@@ -55,19 +55,6 @@ sub _from_hash {
 
 sub _from_hashref {
     return $_[0]->_from_hash(%{ $_[1] });
-}
-
-sub _from_callback {
-    $_[0]->{callback} = $_[1];
-}
-
-sub _unwrap {
-    my ( $self, $ref ) = @_;
-    if (ref $$ref and ref $$ref eq 'CODE') {
-        $$ref = $$ref->();
-        return 1;
-    }
-    return;
 }
 
 sub is_valid {

--- a/t/00.Dmarc.t
+++ b/t/00.Dmarc.t
@@ -66,7 +66,7 @@ sub test_dkim {
     ok( $dmarc->dkim([ \%test_dkim, \%test_dkim ]), "dkim, arrayref set" );
     is_deeply($dmarc->dkim, [ \%test_dkim, \%test_dkim ], "dkim, arrayref set result");
 
-return;
+
     # set with a callback
     $dmarc->{dkim} = undef;
     my $counter  = 0;
@@ -110,14 +110,11 @@ sub test_spf {
     ok( $dmarc->spf([ \%test_spf, \%test_spf ]), "spf, arrayref set" );
     is_deeply($dmarc->spf, [ \%test_spf, \%test_spf ], "spf, arrayref set result");
 
-return;  # drat, I don't know how to fix this...
-
     # set with a callback
     $dmarc->init;
     my $counter  = 0;
     my $callback = sub { $counter++; [ \%test_spf ] };
     ok( $dmarc->spf($callback), "spf, callback set" );
-    warn Dumper($dmarc);
     is($counter, 0, "callback not yet called");
     is_deeply($dmarc->spf, [ \%test_spf ], "spf, callback-derived result");
     is_deeply($dmarc->spf, [ \%test_spf ], "spf, callback-cached result");


### PR DESCRIPTION
The semantics of the spf/dkim methods are a bit odd, in that they are not get/set, but something more like get/push.  It seems to me that the simplest thing to do with callbacks is to restore the previous behavior, where setting a *callback* was not a "push" onto the results of a lazy result, but that it became the newly promised result.  That's what this commit does.  All the previous callback-related tests work again.