### PR TITLE
warn when DMARC record format is invalid

### DIFF
--- a/lib/Mail/DMARC/Result/Reason.pm
+++ b/lib/Mail/DMARC/Result/Reason.pm
@@ -1,4 +1,5 @@
 package Mail::DMARC::Result::Reason;
+# VERSION
 use strict;
 use warnings;
 
@@ -38,7 +39,6 @@ __END__
 sub {}
 
 =head1 OVERVIEW
-
 
 A L<Result|Mail::DMARC::Result> object is the product of instantiating a L<DMARC::PurePerl|Mail::DMARC::PurePerl> object, populating the variables, and running $dmarc->validate. The results object looks like this:
 

--- a/t/01.Policy.t
+++ b/t/01.Policy.t
@@ -131,16 +131,25 @@ sub test_parse {
     $pol = $pol->parse(
         'v=DMARC1; p=reject; rua=mailto:dmarc@example.co; pct=90');
     isa_ok( $pol, 'Mail::DMARC::Policy' );
-    is_deeply(
-        $pol,
-        {   v   => 'DMARC1',
-            p   => 'reject',
-            pct => 90,
-            rua => 'mailto:dmarc@example.co',
-        },
-        'parse'
-    );
+    my $expected = {
+        v   => 'DMARC1',
+        p   => 'reject',
+        pct => 90,
+        rua => 'mailto:dmarc@example.co',
+    };
+    is_deeply( $pol, $expected, 'parse');
 
+    is_deeply(
+        $pol->parse(
+            'v=DMARC1;p=reject;rua=mailto:dmarc-feedback@theartfarm.com;pct=;ruf=mailto:dmarc-feedback@theartfarm.com'
+        ),
+        {
+            v   => 'DMARC1',   p => 'reject',
+            rua => 'mailto:dmarc-feedback@theartfarm.com',
+            ruf => 'mailto:dmarc-feedback@theartfarm.com',
+        },
+        "parse, warns of invalid DMARC record format"
+    );
 }
 
 sub test_is_valid_p {


### PR DESCRIPTION
this is a proposed resolution for #20 

````
 $ perl t/01.Policy.t 
<snip>
ok 24 - An object of class 'Mail::DMARC::Policy' isa 'Mail::DMARC::Policy'
ok 25 - parse
invalid DMARC record detected, please report to
	https://github.com/msimerson/mail-dmarc/issues/39
	v=DMARC1;p=reject;rua=mailto:dmarc-feedback@theartfarm.com;pct=;ruf=mailto:dmarc-feedback@theartfarm.com
ok 26 - parse, warns of invalid DMARC record format
ok 27 - pct, 0
````