### PR TITLE
properly handle multiple DKIM signs in Mail::DKIM

### DIFF
--- a/t/16.Report.Aggregate.Record.Auth_Results.t
+++ b/t/16.Report.Aggregate.Record.Auth_Results.t
@@ -68,38 +68,5 @@ sub _dkim {
     $ar->dkim([ \%dkim_res, \%dkim_res ]);
     is_deeply( $ar->dkim, [ \%dkim_res, \%dkim_res ], "dkim, as arrayref of hashrefs");
 
-
-    $ar = $mod->new;
-    my $dkv = Mail::DKIM::Verifier->new( %dkim_res );
-    $ar->dkim( $dkv );
-    is_deeply( $ar->dkim, [ \%dkim_res ], "dkim, as Mail::DKIM::Verifier");
-
     #warn Dumper($ar->dkim);
 }
-
-
-package Mail::DKIM::Verifier;
-sub new {
-    my ($class, %args) = @_;
-    my $self = bless { signatures => [] }, $class;
-    $self->signatures(%args);
-    return $self;
-}
-sub signatures {
-    my $self = shift;
-    return shift @{ $self->{signatures}} if 0 == scalar @_;
-    push @{ $self->{signatures} }, Mail::DKIM::Signature->new(@_);
-    $self->{signatures};
-}
-
-1;
-
-package Mail::DKIM::Signature;
-sub new { my $class = shift; return bless { @_ }, $class; };
-sub result { return $_[0]->{result}; }
-sub domain { return $_[0]->{domain}; }
-sub selector { return $_[0]->{selector}; }
-sub result_detail {
-    return $_[0]->{result_detail} || $_[0]->{human_result};
-}
-1;


### PR DESCRIPTION
objects. (restore ->signatures iterator to Mail::DKIM class)

intended to fix #41 