### PR TITLE
Psl cache

### DIFF
--- a/lib/Mail/DMARC.pm
+++ b/lib/Mail/DMARC.pm
@@ -18,7 +18,6 @@ sub new {
     my %args = @args;
     my $self = bless {
         config_file => 'mail-dmarc.ini',
-        public_suffixes => {},
         }, $class;
 
     foreach my $key ( keys %args ) {

--- a/t/00.Dmarc.t
+++ b/t/00.Dmarc.t
@@ -193,7 +193,7 @@ sub test_new {
     # empty policy
     my $dmarc = Mail::DMARC->new();
     isa_ok( $dmarc, 'Mail::DMARC' );
-    my $expected = { config_file => 'mail-dmarc.ini', public_suffixes => {} };
+    my $expected = { config_file => 'mail-dmarc.ini' };
     is_deeply( $dmarc, $expected, "new, empty" );
 
     # new, one shot request

--- a/t/12.Report.Store.SQL.t
+++ b/t/12.Report.Store.SQL.t
@@ -141,7 +141,6 @@ sub test_populate_agg_metadata {
             'extra_contact_info' => 'http://www.example.com/dmarc-policy/',
             'org_name' => 'My Great Company',
             'report_id' => 2,
-            'public_suffixes' => {},
         },
         "populate_agg_metadata, deeply" ) or diag Dumper($agg);
 };


### PR DESCRIPTION
Cache the public suffix list at package level to allow subsequent instances of a Mail::DMARC object to use the
cached copy without reloading.

Fixes: #38