### PR TITLE
dmarc_httpd loads PSL before forking & Syslog

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Mail::DMARC - Perl implementation of DMARC
 
 # VERSION
 
-version 1.20150211
+version 1.20150214
 
 # SYNOPSIS
 

--- a/bin/dmarc_httpd
+++ b/bin/dmarc_httpd
@@ -4,9 +4,14 @@ use strict;
 use warnings;
 
 use lib 'lib';
+use Mail::DMARC;
 use Mail::DMARC::HTTP;
+
+my $dmarc = Mail::DMARC->new();
+$dmarc->is_public_suffix('tnpi.net');
+my $report = $dmarc->report;
 my $http = Mail::DMARC::HTTP->new;
-$http->dmarc_httpd;
+$http->dmarc_httpd($report);
 exit;
 
 # ABSTRACT: a web server for DMARC validation and report viewing

--- a/lib/Mail/DMARC.pm
+++ b/lib/Mail/DMARC.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Carp;
+our $psl_loads = 0;
 
 use parent 'Mail::DMARC::Base';
 require Mail::DMARC::Policy;

--- a/lib/Mail/DMARC/Base.pm
+++ b/lib/Mail/DMARC/Base.pm
@@ -89,18 +89,18 @@ sub any_inet_pton {
     my $public_suffixes;
     sub get_public_suffix_list {
         my ( $self ) = @_;
-        if ( ! $public_suffixes ) {
-            my $file = $self->find_psl_file();
-            my $fh = IO::File->new( $file, 'r' )
-                or croak "unable to open $file for read: $!\n";
-            # load PSL into hash for fast lookups, esp. for long running daemons
-            my %psl = map { $_ => 1 }
-                      grep { $_ !~ /^[\/\s]/ } # weed out comments & whitespace
-                      map { chomp($_); $_ }    # remove line endings
-                      <$fh>;
-            $public_suffixes = \%psl;
-        }
-        return $public_suffixes;
+        if ( $public_suffixes ) { return $public_suffixes; }
+        no warnings 'once';
+        $Mail::DMARC::psl_loads++;
+        my $file = $self->find_psl_file();
+        my $fh = IO::File->new( $file, 'r' )
+            or croak "unable to open $file for read: $!\n";
+        # load PSL into hash for fast lookups, esp. for long running daemons
+        my %psl = map { $_ => 1 }
+                  grep { $_ !~ /^[\/\s]/ } # weed out comments & whitespace
+                  map { chomp($_); $_ }    # remove line endings
+                  <$fh>;
+        return $public_suffixes = \%psl;
     }
 }
 

--- a/lib/Mail/DMARC/HTTP.pm
+++ b/lib/Mail/DMARC/HTTP.pm
@@ -12,11 +12,8 @@ use IO::Uncompress::Gunzip;
 use JSON -convert_blessed_universally;
 use URI;
 
-use lib 'lib';
-use Mail::DMARC;
+our $report;
 use Mail::DMARC::PurePerl;
-my $dmarc = Mail::DMARC->new();
-my $report = $dmarc->report;
 
 my %mimes  = (
     css  => 'text/css',
@@ -32,6 +29,7 @@ sub new {
 
 sub dmarc_httpd {
     my $self = shift;
+    $report = shift;
 
     my $port   = $report->config->{http}{port}   || 8080;
     my $ports  = $report->config->{https}{port};
@@ -44,6 +42,9 @@ sub dmarc_httpd {
         ipv   => '*', # IPv6 if available
         ($sslkey ? (SSL_key_file => $sslkey) : ()),
         ($sslcrt ? (SSL_cert_file => $sslcrt) : ()),
+        log_file => 'Sys::Syslog',
+        syslog_ident => 'mail_dmarc',
+        syslog_facility => 'MAIL',
     );
     return;
 };

--- a/t/03.Base.t
+++ b/t/03.Base.t
@@ -36,6 +36,7 @@ __is_valid_domain();
 __epoch_to_iso();
 __get_prefix();
 __get_sharefile();
+__psl_cached();
 
 done_testing();
 exit;
@@ -173,4 +174,9 @@ sub __get_sharefile {
 
         ok($r, "get_sharefile: $r");
     };
+}
+
+sub __psl_cached {
+    no warnings 'once';
+    cmp_ok($Mail::DMARC::psl_loads, '==', 1, 'Public Suffix List cached');
 }


### PR DESCRIPTION
* loads the PSL in dmarc_httpd and passes it into Net::Server::HTTP, so it gets loaded once before forking.
* loads messages to Syslog (MAIL facility)

closes #38 