### PR TITLE
Report send verbose

### DIFF
--- a/bin/dmarc_send_reports
+++ b/bin/dmarc_send_reports
@@ -48,9 +48,9 @@ if ( $report->config->{report_sign}->{keyfile} ) {
 # 1. get reports, one at a time
 while (defined(my $aggregate = $report->store->retrieve_todo ) ) {
 
-    print "ID: " . $aggregate->metadata->report_id . "\n";
-    print $aggregate->policy_published->domain . "\n";
-    print "rua:\t" . $aggregate->policy_published->rua . "\n";
+    print 'ID:     ' . $aggregate->metadata->report_id . "\n";
+    print 'Domain: ' . $aggregate->policy_published->domain . "\n";
+    print 'rua:    ' . $aggregate->policy_published->rua . "\n";
 
     my $xml = $aggregate->as_xml();
 #   warn $xml;  ## no critic (Carp)
@@ -105,9 +105,9 @@ while (defined(my $aggregate = $report->store->retrieve_todo ) ) {
     };
 
     if ( $send_delay > 0 ) {
-        print "sleeping $send_delay";
-        foreach ( 1 .. $send_delay ) { print '.'; sleep 1; };
-        print "done.\n";
+        print "sleeping $send_delay" if $verbose;
+        foreach ( 1 .. $send_delay ) { print '.' if $verbose; sleep 1; };
+        print "done.\n" if $verbose;
     }
 };
 

--- a/lib/Mail/DMARC/Report/Store/SQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL.pm
@@ -96,7 +96,7 @@ sub retrieve_todo {
 sub delete_report {
     my $self = shift;
     my $report_id = shift or croak "missing report ID";
-    print "deleting report $report_id\n";
+    print "deleting report $report_id\n" if $self->verbose;
 
     # deletes with FK don't cascade in SQLite? Clean each table manually
     my $rows = $self->query( 'SELECT id FROM report_record WHERE report_id=?',
@@ -105,7 +105,7 @@ sub delete_report {
     foreach my $table (
         qw/ report_record_spf report_record_dkim report_record_reason /)
     {
-        print "deleting $table rows $row_ids\n";
+        print "deleting $table rows $row_ids\n" if $self->verbose;
         $self->query(
             "DELETE FROM $table WHERE report_record_id IN ($row_ids)");
     }


### PR DESCRIPTION
Hide some detail when --verbose is not used on dmarc_send_reports, also tidy the output a little.