### PR TITLE
Fix the policy_evaluated fields in outbound reports

### DIFF
--- a/lib/Mail/DMARC/Report/Aggregate.pm
+++ b/lib/Mail/DMARC/Report/Aggregate.pm
@@ -142,7 +142,7 @@ sub get_policy_evaluated_as_xml {
     my $pe = "\t\t\t<policy_evaluated>\n";
 
     foreach my $f (qw/ disposition dkim spf /) {
-        $pe .= "\t\t\t\t<$f>$rec->row->policy_evaluated->$f</$f>\n";
+        $pe .= "\t\t\t\t<$f>$rec->{row}{policy_evaluated}{$f}</$f>\n";
     }
 
     my $reasons = $rec->{row}{policy_evaluated}{reason};


### PR DESCRIPTION
The outgoing policy evaluated fields in outgoing reports had been broken, resulting in reports with the following kind of errors included being sent.

                        <policy_evaluated>
                                <disposition>Mail::DMARC::Report::Aggregate::Record=HASH(0x39f1520)->row->policy_evaluated->disposition</disposition>
                                <dkim>Mail::DMARC::Report::Aggregate::Record=HASH(0x39f1520)->row->policy_evaluated->dkim</dkim>
                                <spf>Mail::DMARC::Report::Aggregate::Record=HASH(0x39f1520)->row->policy_evaluated->spf</spf>
                        </policy_evaluated>

This fixes the errors. I think some tests should be added to cover outbound reports.
