### PR TITLE
Missing PreReq added

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -92,13 +92,14 @@ skip = ^MIME::Lite$
 ;skip = ^Net::Server
 
 [Prereqs]
-perl                   = 5.008
-Regexp::Common         = 2013031301
-Config::Tiny           = 0
-File::ShareDir         = 0
-Net::DNS::Resolver     = 0
-Net::IP                = 0
-Socket6                = 0.23
+perl                      = 5.008
+Regexp::Common            = 2013031301
+Config::Tiny              = 0
+File::ShareDir            = 0
+File::ShareDir::Install   = 0
+Net::DNS::Resolver        = 0
+Net::IP                   = 0
+Socket6                   = 0.23
 Email::MIME               = 0
 HTTP::Tiny                = 0
 IO::Socket::SSL           = 0


### PR DESCRIPTION
Install on a new debian host gives the following error...

root@lorien ~/git/mail-dmarc(fastmail)$ perl Makefile.PL
Can't locate File/ShareDir/Install.pm in @INC (@INC contains: /etc/perl /usr/local/lib/perl/5.14.2 /usr/local/share/perl/5.14.2 /usr/lib/perl5 /usr/share/perl5 /usr/lib/perl/5.14 /usr/share/perl/5.14 /usr/local/lib/site_perl .) at Makefile.PL line 10.
BEGIN failed--compilation aborted at Makefile.PL line 10.

Adding this modue to the prereq list.