### PR TITLE
put the Mail::DMARC::Result documentation in Mail::DMARC::Result

### DIFF
--- a/lib/Mail/DMARC/Result.pm
+++ b/lib/Mail/DMARC/Result.pm
@@ -86,4 +86,87 @@ sub reason {
 1;
 
 # ABSTRACT: an aggregate report result object
+__END__
+
+=head1 OVERVIEW
+
+A L<Result|Mail::DMARC::Result> object is the product of instantiating a L<DMARC::PurePerl|Mail::DMARC::PurePerl> object, populating the variables, and running $dmarc->validate. The results object looks like this:
+
+    result       => 'pass',   # pass, fail
+    disposition  => 'none',   # reject, quarantine, none
+    reason       => [         # there can be many reasons...
+            {
+                type     => '',   # forwarded, sampled_out, trusted_forwarder,
+                comment  => '',   #   mailing_list, local_policy, other
+            },
+        ],
+    dkim         => 'pass',   # pass, fail
+    dkim_align   => 'strict', # strict, relaxed
+    spf          => 'pass',   # pass, fail
+    spf_align    => 'strict', # strict, relaxed
+    published    => L<Mail::DMARC::Policy>,
+
+Reasons are optional and may not be present.
+
+The dkim_align and spf_align fields will only be present if the corresponding test value equals pass. They are additional info not specified by the DMARC spec.
+
+=head1 METHODS
+
+=head2 published
+
+Published is a L<Mail::DMARC::Policy> tagged with a domain. The domain attribute is the DNS domain name where the DMARC record was found. This may not be the same as the header_from domain (ex: bounces.amazon.com -vs- amazon.com).
+
+=head2 result
+
+Whether the message passed the DMARC test. Possible values are: pass, fail.
+
+In order to pass, at least one authentication alignment must pass. The 2013 draft defines two authentication methods: DKIM and SPF. The list is expected to grow.
+
+=head2 disposition
+
+When the DMARC result is not I<pass>, disposition is the results of applying DMARC policy to a message. Generally this is the same as the header_from domains published DMARC L<policy|Mail::DMARC::Policy>. When it is not, the reason SHOULD be specified.
+
+=head2 dkim
+
+Whether the message passed or failed DKIM alignment. In order to pass the DMARC DKIM alignment test, a DKIM signature that matches the RFC5322.From domain must be present. An unsigned messsage, a message with an invalid signature, or signatures that don't match the RFC5322.From field are all considered failures.
+
+=head2 dkim_align
+
+If the message passed the DKIM alignment test, this indicates whether the alignment was strict or relaxed.
+
+=head2 spf
+
+Whether the message passed or failed SPF alignment. To pass SPF alignment, the RFC5321.MailFrom domain must match the RFC5322.From field.
+
+=head2 spf_align
+
+If the message passed the SPF alignment test, this indicates whether the alignment was strict or relaxed.
+
+=head2 reason
+
+If the applied policy differs from the sites published policy, the result policy should contain a reason and optionally a comment.
+
+A DMARC result reason has two attributes, type, and comment.
+
+    reason => {
+        type =>  '',
+        comment => '',
+    },
+
+=head3 type
+
+The following reason types are defined and valid:
+
+    forwarded
+    sampled_out
+    trusted_forwarder
+    mailing_list
+    local_policy
+    other
+
+=head3 comment
+
+Comment is a free form text field.
+
+=cut
 

--- a/lib/Mail/DMARC/Result/Reason.pm
+++ b/lib/Mail/DMARC/Result/Reason.pm
@@ -36,86 +36,14 @@ sub comment {
 
 # ABSTRACT: policy override reason
 __END__
-sub {}
-
-=head1 OVERVIEW
-
-A L<Result|Mail::DMARC::Result> object is the product of instantiating a L<DMARC::PurePerl|Mail::DMARC::PurePerl> object, populating the variables, and running $dmarc->validate. The results object looks like this:
-
-    result       => 'pass',   # pass, fail
-    disposition  => 'none',   # reject, quarantine, none
-    reason       => [         # there can be many reasons...
-            {
-                type     => '',   # forwarded, sampled_out, trusted_forwarder,
-                comment  => '',   #   mailing_list, local_policy, other
-            },
-        ],
-    dkim         => 'pass',   # pass, fail
-    dkim_align   => 'strict', # strict, relaxed
-    spf          => 'pass',   # pass, fail
-    spf_align    => 'strict', # strict, relaxed
-    published    => L<Mail::DMARC::Policy>,
-
-Reasons are optional and may not be present.
-
-The dkim_align and spf_align fields will only be present if the corresponding test value equals pass. They are additional info not specified by the DMARC spec.
 
 =head1 METHODS
 
-=head2 published
+=head2 type
 
-Published is a L<Mail::DMARC::Policy> tagged with a domain. The domain attribute is the DNS domain name where the DMARC record was found. This may not be the same as the header_from domain (ex: bounces.amazon.com -vs- amazon.com).
+Type is the type of override used, and is one of a number of fixed strings.
 
-=head2 result
+=head2 comment
 
-Whether the message passed the DMARC test. Possible values are: pass, fail.
+Comment may or may not be present, and may be anything.
 
-In order to pass, at least one authentication alignment must pass. The 2013 draft defines two authentication methods: DKIM and SPF. The list is expected to grow.
-
-=head2 disposition
-
-When the DMARC result is not I<pass>, disposition is the results of applying DMARC policy to a message. Generally this is the same as the header_from domains published DMARC L<policy|Mail::DMARC::Policy>. When it is not, the reason SHOULD be specified.
-
-=head2 dkim
-
-Whether the message passed or failed DKIM alignment. In order to pass the DMARC DKIM alignment test, a DKIM signature that matches the RFC5322.From domain must be present. An unsigned messsage, a message with an invalid signature, or signatures that don't match the RFC5322.From field are all considered failures.
-
-=head2 dkim_align
-
-If the message passed the DKIM alignment test, this indicates whether the alignment was strict or relaxed.
-
-=head2 spf
-
-Whether the message passed or failed SPF alignment. To pass SPF alignment, the RFC5321.MailFrom domain must match the RFC5322.From field.
-
-=head2 spf_align
-
-If the message passed the SPF alignment test, this indicates whether the alignment was strict or relaxed.
-
-=head2 reason
-
-If the applied policy differs from the sites published policy, the result policy should contain a reason and optionally a comment.
-
-A DMARC result reason has two attributes, type, and comment.
-
-    reason => {
-        type =>  '',
-        comment => '',
-    },
-
-=head3 type
-
-The following reason types are defined and valid:
-
-    forwarded
-    sampled_out
-    trusted_forwarder
-    mailing_list
-    local_policy
-    other
-
-=head3 comment
-
-Comment is a free form text field.
-
-=cut


### PR DESCRIPTION
The docs for Result ended up in Result::Reason at some point.  Ooops! :-)