### PR TITLE
swap contributors-from-git plugin

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -33,7 +33,7 @@ filename = .mailmap
 format = 1.{{ cldr('yyyyMMdd') }}
 ;[Git::NextVersion]  <- worth considering
 
-[ContributorsFromGit]
+[Git::Contributors]
 ;[ReadmeFromPod]
 ;[ReadmeMarkdownFromPod]
 [ReadmeAnyFromPod]


### PR DESCRIPTION
The one currently used is broken, at least on 5.21.x, and the
maintainer seems to have gone on holiday.

Running "dzil test" on this resulted in one potential problems:  `README.md` was changed, but the change seems reasonable.  I leave it to you to decide.