### PR TITLE
Allow configurable batches of reports to be sent before delay kicks in

### DIFF
--- a/bin/dmarc_send_reports
+++ b/bin/dmarc_send_reports
@@ -9,10 +9,12 @@ use Getopt::Long;
 #use XML::LibXML;
 
 my $send_delay = 5;
+my $batch_size = 1;
 
 GetOptions (
     'verbose+'   => \my $verbose,
     'delay=i'    => \$send_delay,
+    'batch=i'    => \$batch_size,
 );
 
 $|++;
@@ -44,6 +46,8 @@ if ( $report->config->{report_sign}->{keyfile} ) {
         die 'DKIM signing requested but Mail::DKIM could not be loaded. Please check that Mail::DKIM is installed.';
     }
 }
+
+my $batch_do = 1;
 
 # 1. get reports, one at a time
 while (defined(my $aggregate = $report->store->retrieve_todo ) ) {
@@ -104,10 +108,13 @@ while (defined(my $aggregate = $report->store->retrieve_todo ) ) {
         send_too_big_email(\@too_big, $bytes, $aggregate);
     };
 
-    if ( $send_delay > 0 ) {
-        print "sleeping $send_delay" if $verbose;
-        foreach ( 1 .. $send_delay ) { print '.' if $verbose; sleep 1; };
-        print "done.\n" if $verbose;
+    if ( $batch_do++ > $batch_size ) {
+        $batch_do = 1;
+        if ( $send_delay > 0 ) {
+            print "sleeping $send_delay" if $verbose;
+            foreach ( 1 .. $send_delay ) { print '.' if $verbose; sleep 1; };
+            print "done.\n" if $verbose;
+        }
     }
 };
 


### PR DESCRIPTION
We are tweaking our report sending at the moment, with the recent change in reporting time window we see a surge of reports just after the start of utc day.
This change allows us to send more reports than 1 per second, but still introduce a delay to the process.
