### PR TITLE
Optionally squash reporting sub domains into their org domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Mail::DMARC - Perl implementation of DMARC
 
 # VERSION
 
-version 1.20150311
+version 1.20150316
 
 # SYNOPSIS
 
@@ -283,7 +283,6 @@ Qpsmtpd plugin: https://github.com/smtpd/qpsmtpd/blob/master/plugins/dmarc
 # CONTRIBUTORS
 
 - Benny Pedersen <me@junc.eu>
-- ColocateUSA.net <company@colocateusa.net>
 - Marc Bradshaw <marc@marcbradshaw.net>
 - Ricardo Signes <rjbs@cpan.org>
 - Ricardo Signes <rjbs@users.noreply.github.com>

--- a/lib/Mail/DMARC/Policy.pm
+++ b/lib/Mail/DMARC/Policy.pm
@@ -65,6 +65,11 @@ sub apply_defaults {
     return 1;
 }
 
+sub policy_from_dns_domain {
+    return $_[0]->{policy_from_dns_domain} if 1 == scalar @_;
+    return $_[0]->{policy_from_dns_domain} = $_[1];
+}
+
 sub v {
     return $_[0]->{v} if 1 == scalar @_;
     croak "unsupported DMARC version" if 'DMARC1' ne uc $_[1];

--- a/lib/Mail/DMARC/Report/Store/SQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL.pm
@@ -160,8 +160,8 @@ sub get_report_id {
         ? $self->config->{report_sending}{squash_domain_reports}
         : 1;
     if ( $squash_domain_reports ) {
-        if ( lc $pol->policy_from_domain ne lc $pol->domain &&
-             lc $pol->policy_from_domain eq lc $self->get_organizational_domain( $pol->domain )
+        if ( lc $pol->policy_from_dns_domain ne lc $pol->domain &&
+             lc $pol->policy_from_dns_domain eq lc $self->get_organizational_domain( $pol->domain )
         ) {
             $from_dom_id = $self->get_domain_id( $self->get_organizational_domain( $pol->domain ) )  or croak;
         }

--- a/lib/Mail/DMARC/Report/Store/SQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL.pm
@@ -155,10 +155,14 @@ sub get_report_id {
     my $author_id   = $self->get_author_id( $meta )         or croak;
     my $from_dom_id = $self->get_domain_id( $pol->domain )  or croak;
 
-    if ( $self->config->{report_sending}{squash_domain_reports} ) {
-        if ( lc $pol->policy_from_dns_domain ne lc $pol->domain &&
-             lc $pol->policy_from_dns_domain eq lc $self->get_organizational_domain( $pol->domain ) )
-        {
+    my $squash_domain_reports =
+        exists $self->config->{report_sending}->{squash_domain_reports}
+        ? $self->config->{report_sending}{squash_domain_reports}
+        : 1;
+    if ( $squash_domain_reports ) {
+        if ( lc $pol->policy_from_domain ne lc $pol->domain &&
+             lc $pol->policy_from_domain eq lc $self->get_organizational_domain( $pol->domain )
+        ) {
             $from_dom_id = $self->get_domain_id( $self->get_organizational_domain( $pol->domain ) )  or croak;
         }
     }

--- a/lib/Mail/DMARC/Report/Store/SQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL.pm
@@ -155,6 +155,14 @@ sub get_report_id {
     my $author_id   = $self->get_author_id( $meta )         or croak;
     my $from_dom_id = $self->get_domain_id( $pol->domain )  or croak;
 
+    if ( $self->config->{report_sending}{squash_domain_reports} ) {
+        if ( lc $pol->policy_from_dns_domain ne lc $pol->domain &&
+             lc $pol->policy_from_dns_domain eq lc $self->get_organizational_domain( $pol->domain ) )
+        {
+            $from_dom_id = $self->get_domain_id( $self->get_organizational_domain( $pol->domain ) )  or croak;
+        }
+    }
+
     my $ids;
     if ( $meta->report_id ) {
     # reports arriving via the wire will have an author ID & report ID

--- a/share/mail-dmarc.ini
+++ b/share/mail-dmarc.ini
@@ -36,6 +36,11 @@ keyfile     = /path/to/private.key
 ; maximum reporting interval in seconds: default: none
 ; max_interval = 86400
 
+; squash reports for sub domains without their own
+; DMARC records into the reports for the overall
+; organizational domain.
+; squash_domain_reports = 1
+
 ; backend can be perl or libopendmarc
 [dmarc]
 backend        = perl

--- a/t/04.PurePerl.t
+++ b/t/04.PurePerl.t
@@ -218,6 +218,7 @@ sub test_discover_policy {
         rf    => 'afrf',
         fo    => 0,
         domain => 'mail-dmarc.tnpi.net',
+        policy_from_dns_domain => 'mail-dmarc.tnpi.net',
     };
     is_deeply( $policy, $expected, 'discover_policy, deeply' );
 

--- a/t/12.Report.Store.SQL.t
+++ b/t/12.Report.Store.SQL.t
@@ -152,6 +152,7 @@ sub test_get_report_policy_published {
     foreach ( qw/ sp pct / ) {
         delete $pp->{$_} if ! defined $pp->$_;
     };
+    $pp->policy_from_dns_domain( 'recip.example.com' );
     delete $pp->{report_id};
     delete $policy->{uri};
     ok( $pp, "get_report_policy_published");
@@ -247,6 +248,7 @@ sub test_get_author_id {
     }
 
     my $policy = Mail::DMARC::Policy->new("v=DMARC1; p=reject");
+    $policy->policy_from_dns_domain( 'recip.example.com' );
     ok( $policy->rua( 'mailto:' . $sql->config->{organization}{email} ), "policy, rua, set");
     ok( $policy->domain( 'recip.example.com'), "policy, domain, set");
     ok( $report->aggregate->policy_published( $policy ), "policy published, set");
@@ -271,6 +273,7 @@ sub test_get_report_id {
         ok( $report->aggregate->metadata->$_( $meta{$_} ), "meta, $_, set" );
     }
     $policy = Mail::DMARC::Policy->new("v=DMARC1; p=reject");
+    $policy->policy_from_dns_domain( 'recip.example.com' );
     $policy->apply_defaults;
     ok( $policy->rua( 'mailto:' . $sql->config->{organization}{email} ), "policy, rua, set");
     ok( $policy->domain( 'recip.example.com'), "policy, domain, set");
@@ -325,6 +328,7 @@ sub test_insert_rr {
 
 sub test_insert_policy_published {
     my $pol = Mail::DMARC::Policy->new('v=DMARC1; p=none');
+    $policy->policy_from_dns_domain( 'recip.example.com' );
     $pol->apply_defaults;
     $pol->rua( 'mailto:' . $sql->config->{organization}{email} );
 #   warn Dumper($policy);


### PR DESCRIPTION
Add a configuration option to allow sub domains without an explicit DMARC record to be reported in the report for the overall organizational domain.

@msimerson can you take a look and comment, thanks.

This should fix #59
