### PR TITLE
Optionally squash reporting sub domains into their org domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Mail::DMARC - Perl implementation of DMARC
 
 # VERSION
 
-version 1.20150311
+version 1.20150317
 
 # SYNOPSIS
 
@@ -283,7 +283,6 @@ Qpsmtpd plugin: https://github.com/smtpd/qpsmtpd/blob/master/plugins/dmarc
 # CONTRIBUTORS
 
 - Benny Pedersen <me@junc.eu>
-- ColocateUSA.net <company@colocateusa.net>
 - Marc Bradshaw <marc@marcbradshaw.net>
 - Ricardo Signes <rjbs@cpan.org>
 - Ricardo Signes <rjbs@users.noreply.github.com>

--- a/t/04.PurePerl.t
+++ b/t/04.PurePerl.t
@@ -427,41 +427,41 @@ sub test_get_organizational_domain {
 }
 
 sub test_fetch_dmarc_record {
-    my $matches = $dmarc->fetch_dmarc_record('mail-dmark.tnpi.net');
+    my ($matches) = $dmarc->fetch_dmarc_record('mail-dmark.tnpi.net');
     is_deeply( $matches, [], 'fetch_dmarc_record, non-exist' );
 
     #warn Dumper($matches);
 
-    $matches = $dmarc->fetch_dmarc_record('mail-dmarc.tnpi.net');
+    ($matches) = $dmarc->fetch_dmarc_record('mail-dmarc.tnpi.net');
     is_deeply( $matches, [$test_rec], 'fetch_dmarc_record' );
 
-    $matches = $dmarc->fetch_dmarc_record('one_one.test.dmarc-qa.com');
+    ($matches) = $dmarc->fetch_dmarc_record('one_one.test.dmarc-qa.com');
     my $policy = $dmarc->policy->parse( $matches->[0] );
     cmp_ok( $policy->p, 'eq', 'reject', "fetch_dmarc_record, 1.2.1 one_one.test.dmarc-qa.com" );
 
-    $matches = $dmarc->fetch_dmarc_record('dmarc-qafail.com');
+    ($matches) = $dmarc->fetch_dmarc_record('dmarc-qafail.com');
     cmp_ok( 0, '==', scalar @$matches, "fetch_dmarc_record, 1.2.2 DNS error");
 
-    $matches = $dmarc->fetch_dmarc_record('alt.dmarc-qa.com');
+    ($matches) = $dmarc->fetch_dmarc_record('alt.dmarc-qa.com');
     $policy = $dmarc->policy->parse( $matches->[0] );
     cmp_ok( $policy->p, 'eq', 'none', "fetch_dmarc_record, 1.2.3 DNS error subdomain");
 
-    $matches = $dmarc->fetch_dmarc_record('servfail.dmarc-qa.com');
+    ($matches) = $dmarc->fetch_dmarc_record('servfail.dmarc-qa.com');
     eval { $policy = $dmarc->policy->parse( $matches->[0] ) } if scalar @$matches;
     cmp_ok( $policy->p, 'eq', 'none', "fetch_dmarc_record, 1.2.3 DNS srvfail");
 
-    $matches = $dmarc->fetch_dmarc_record('com');
+    ($matches) = $dmarc->fetch_dmarc_record('com');
     is_deeply( $matches, [], 'fetch_dmarc_record, 1.2.4 TLD lookup not allowed' );
 
-    $matches = $dmarc->fetch_dmarc_record('cn.dmarc-qa.com');
+    ($matches) = $dmarc->fetch_dmarc_record('cn.dmarc-qa.com');
     eval { $policy = $dmarc->policy->parse( $matches->[0] ) } if scalar @$matches;
     cmp_ok( $policy->p, 'eq', 'reject', "fetch_dmarc_record, 1.2.5 CNAME results in Org match");
 
-    $matches = $dmarc->fetch_dmarc_record('unrelated.dmarc-qa.com');
+    ($matches) = $dmarc->fetch_dmarc_record('unrelated.dmarc-qa.com');
     eval { $policy = $dmarc->policy->parse( $matches->[0] ) } if scalar @$matches;
     cmp_ok( $policy->p, 'eq', 'reject', "fetch_dmarc_record, 1.3.1 unrelated TXT");
 
-    $matches = $dmarc->fetch_dmarc_record('mixed.dmarc-qa.com');
+    ($matches) = $dmarc->fetch_dmarc_record('mixed.dmarc-qa.com');
     eval { $policy = $dmarc->policy->parse( $matches->[0] ) } if scalar @$matches;
     cmp_ok( $policy->p, 'eq', 'none', "fetch_dmarc_record, 1.3.1 mixed TXT");
 


### PR DESCRIPTION
Cause reports to be sent to the organizational domain when a sub domain
does not have an explicit DMARC record of its own.

Closes #61 