### PR TITLE
Add timeouts to report sending

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 
 {{$NEXT}}
 
+ - add timeout to sending script
+
 1.20150317 2015-03-17 America/Los_Angeles
 
  - squash subdomains w/o DMARC records into parent report (#59)

--- a/bin/dmarc_send_reports
+++ b/bin/dmarc_send_reports
@@ -10,11 +10,13 @@ use Getopt::Long;
 
 my $send_delay = 5;
 my $batch_size = 1;
+my $alarm_at   = 120;
 
 GetOptions (
     'verbose+'   => \my $verbose,
     'delay=i'    => \$send_delay,
     'batch=i'    => \$batch_size,
+    'timeout=i'  => \$alarm_at,
 );
 
 $|++;
@@ -49,8 +51,13 @@ if ( $report->config->{report_sign}->{keyfile} ) {
 
 my $batch_do = 1;
 
+local $SIG{'ALRM'} = sub{ die "timeout\n" };
+alarm($alarm_at);
+
 # 1. get reports, one at a time
 while (defined(my $aggregate = $report->store->retrieve_todo ) ) {
+
+    alarm($alarm_at);
 
     print 'ID:     ' . $aggregate->metadata->report_id . "\n";
     print 'Domain: ' . $aggregate->policy_published->domain . "\n";
@@ -111,12 +118,16 @@ while (defined(my $aggregate = $report->store->retrieve_todo ) ) {
     if ( $batch_do++ > $batch_size ) {
         $batch_do = 1;
         if ( $send_delay > 0 ) {
+            alarm(0);
             print "sleeping $send_delay" if $verbose;
             foreach ( 1 .. $send_delay ) { print '.' if $verbose; sleep 1; };
             print "done.\n" if $verbose;
+            alarm($alarm_at);
         }
     }
 };
+
+alarm(0);
 
 exit;
 # PODNAME: dmarc_send_reports


### PR DESCRIPTION
We have had an incident where the sender process became deadlocked.
I suspect it may have been a database issue, but didn't have enough data to find the root cause, on restarting the sending completed as normal.
Time outs have been added to avoid this happening again.