### PR TITLE
Reorder report metadata in rua report to match order in schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Mail::DMARC - Perl implementation of DMARC
 
 # VERSION
 
-version 1.20150817
+version 1.20150819
 
 # SYNOPSIS
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Mail::DMARC - Perl implementation of DMARC
 
 # VERSION
 
-version 1.20150708
+version 1.20150817
 
 # SYNOPSIS
 

--- a/dist.ini
+++ b/dist.ini
@@ -129,6 +129,8 @@ Net::HTTP                 = 0
 
 [Prereqs / TestRecommends]
 Test::Output              = 0
+XML::SAX::ParserFactory   = 0
+XML::Validator::Schema    = 0
 
 ; TODO: neither the FileFinder nor the skip work for ExecDir. I would rather
 ; not install bin/install_deps.pl

--- a/lib/Mail/DMARC/Report/Aggregate.pm
+++ b/lib/Mail/DMARC/Report/Aggregate.pm
@@ -56,6 +56,7 @@ sub as_xml {
     return <<"EO_XML"
 <?xml version="1.0"?>
 <feedback>
+\t<version>1.0</version>
 $meta
 $pubp
 $reco</feedback>
@@ -129,7 +130,7 @@ sub get_policy_published_as_xml {
     my $self = shift;
     my $pp = $self->policy_published or return '';
     my $xml = "\t<policy_published>\n\t\t<domain>$pp->{domain}</domain>\n";
-    foreach my $f (qw/ adkim aspf p sp pct /) {
+    foreach my $f (qw/ adkim aspf p sp pct fo /) {
         my $v = $pp->{$f};
         # Set some default values for missing optional fields if necessary
         if ( $f eq 'sp' && !defined $v ) {
@@ -137,6 +138,9 @@ sub get_policy_published_as_xml {
         }
         if ( $f eq 'pct' && !defined $v ) {
             $v = '100';
+        }
+        if ( $f eq 'fo' && !defined $v ) {
+            $v = '0';
         }
         next if !defined $v;
         $xml .= "\t\t<$f>$v</$f>\n";

--- a/lib/Mail/DMARC/Report/Aggregate/Metadata.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Metadata.pm
@@ -54,10 +54,9 @@ sub uuid {
 
 sub as_xml {
     my $self = shift;
-    my $meta = "\t<report_metadata>\n\t\t<report_id>"
-             . $self->report_id . "</report_id>\n";
+    my $meta = "\t<report_metadata>\n";
 
-    foreach my $f (qw/ org_name email extra_contact_info /) {
+    foreach my $f (qw/ org_name email extra_contact_info report_id /) {
         my $val = $self->$f or next;
         $meta .= "\t\t<$f>$val</$f>\n";
     }

--- a/t/14.Report.Aggregate.Metadata.t
+++ b/t/14.Report.Aggregate.Metadata.t
@@ -89,10 +89,10 @@ sub test_uuid  {
 sub test_as_xml  {
     my $expected = <<"EO_XML"
 \t<report_metadata>
-\t\t<report_id>12345566677888\@sender.com</report_id>
 \t\t<org_name>Test Org</org_name>
 \t\t<email>test\@example.com</email>
 \t\t<extra_contact_info>http://www.example.com/path/to/dmarc.cgi</extra_contact_info>
+\t\t<report_id>12345566677888\@sender.com</report_id>
 \t\t<date_range>
 \t\t\t<begin>$start</begin>
 \t\t\t<end>$end</end>

--- a/t/17.Report.Aggregate.Schema.t
+++ b/t/17.Report.Aggregate.Schema.t
@@ -1,0 +1,86 @@
+use strict;
+use warnings;
+
+use Data::Dumper;
+use Test::Exception;
+use Test::More;
+
+use lib 'lib';
+use Mail::DMARC::PurePerl;
+use Mail::DMARC::Report;
+
+eval "use DBD::SQLite 1.31";
+if ($@) {
+    plan( skip_all => 'DBD::SQLite not available' );
+    exit;
+}
+            
+eval "use XML::SAX::ParserFactory;";
+if ($@) {
+    plan( skip_all => 'XML::SAX::ParserFactory not available' );
+    exit;
+}
+
+eval "use XML::Validator::Schema;";
+if ($@) {
+    plan( skip_all => 'XML::Validator::Schema not available' );
+    exit;
+}
+
+my $dmarc = Mail::DMARC::PurePerl->new();
+
+$dmarc->source_ip('66.128.51.165');
+$dmarc->envelope_to('recipient.example.com');
+$dmarc->envelope_from('dmarc-nonexist.tnpi.net');
+$dmarc->header_from('mail-dmarc.tnpi.net');
+$dmarc->dkim([
+        {
+        domain      => 'tnpi.net',
+        selector    => 'jan2015',
+        result      => 'fail',
+        human_result=> 'fail (body has been altered)',
+    }
+]);
+$dmarc->spf([
+        {   domain => 'tnpi.net',
+            scope  => 'mfrom',
+            result => 'pass',
+        },
+        {
+            scope  => 'helo',
+            domain => 'mail.tnpi.net',
+            result => 'fail',
+        },
+    ]);
+
+my $policy = $dmarc->discover_policy;
+my $result = $dmarc->validate($policy);
+$dmarc->save_aggregate();
+
+my $store = $dmarc->{'report'}->{'store'};
+
+die 'Not using test store' if $store->{'SQL'}->{'config'}->{'report_store'}->{'dsn'} ne 'dbi:SQLite:dbname=:memory:';
+
+my $a = $store->{'SQL'}->query('UPDATE report SET begin=begin-86400, end=end-86400 WHERE id=1');
+
+my $agg = $store->retrieve_todo();
+
+test_against_schema();
+
+done_testing();
+exit;
+
+sub test_against_schema {
+
+    $agg->metadata->report_id(1);
+
+    my $xml = $agg->as_xml();
+    lives_ok( sub{
+        my $validator = XML::Validator::Schema->new(file => 't/rua-schema.xsd');
+        my $parser = XML::SAX::ParserFactory->parser(Handler => $validator);
+        $parser->parse_string( $xml );
+    }, 'Check schema' );
+    # print $xml;
+
+};
+

--- a/t/rua-schema.xsd
+++ b/t/rua-schema.xsd
@@ -1,0 +1,260 @@
+<?xml version="1.0"?>
+   <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+     targetNamespace="http://dmarc.org/dmarc-xml/0.1">
+
+   <!-- The time range in UTC covered by messages in this report,
+        specified in seconds since epoch. -->
+   <xs:complexType name="DateRangeType">
+     <xs:all>
+       <xs:element name="begin" type="xs:integer"/>
+       <xs:element name="end" type="xs:integer"/>
+     </xs:all>
+   </xs:complexType>
+
+   <!-- Report generator metadata. -->
+   <xs:complexType name="ReportMetadataType">
+     <xs:sequence>
+       <xs:element name="org_name" type="xs:string"/>
+       <xs:element name="email" type="xs:string"/>
+       <xs:element name="extra_contact_info" type="xs:string"
+                   minOccurs="0"/>
+       <xs:element name="report_id" type="xs:string"/>
+       <xs:element name="date_range" type="DateRangeType"/>
+       <xs:element name="error" type="xs:string" minOccurs="0"
+                   maxOccurs="unbounded"/>
+     </xs:sequence>
+   </xs:complexType>
+
+   <!-- Alignment mode (relaxed or strict) for DKIM and SPF. -->
+   <xs:simpleType name="AlignmentType">
+     <xs:restriction base="xs:string">
+       <xs:enumeration value="r"/>
+       <xs:enumeration value="s"/>
+     </xs:restriction>
+   </xs:simpleType>
+
+   <!-- The policy actions specified by p and sp in the
+        DMARC record. -->
+   <xs:simpleType name="DispositionType">
+     <xs:restriction base="xs:string">
+       <xs:enumeration value="none"/>
+       <xs:enumeration value="quarantine"/>
+       <xs:enumeration value="reject"/>
+     </xs:restriction>
+   </xs:simpleType>
+
+   <!-- The DMARC policy that applied to the messages in
+        this report. -->
+   <xs:complexType name="PolicyPublishedType">
+     <xs:all>
+       <!-- The domain at which the DMARC record was found. -->
+       <xs:element name="domain" type="xs:string"/>
+       <!-- The DKIM alignment mode. -->
+       <xs:element name="adkim" type="AlignmentType"
+                   minOccurs="0"/>
+       <!-- The SPF alignment mode. -->
+       <xs:element name="aspf" type="AlignmentType"
+                   minOccurs="0"/>
+       <!-- The policy to apply to messages from the domain. -->
+       <xs:element name="p" type="DispositionType"/>
+       <!-- The policy to apply to messages from subdomains. -->
+       <xs:element name="sp" type="DispositionType"/>
+       <!-- The percent of messages to which policy applies. -->
+       <xs:element name="pct" type="xs:integer"/>
+       <!-- Failure reporting options in effect. -->
+       <xs:element name="fo" type="xs:string"/>
+     </xs:all>
+   </xs:complexType>
+
+   <!-- The DMARC-aligned authentication result. -->
+   <xs:simpleType name="DMARCResultType">
+     <xs:restriction base="xs:string">
+       <xs:enumeration value="pass"/>
+       <xs:enumeration value="fail"/>
+     </xs:restriction>
+   </xs:simpleType>
+
+   <!-- Reasons that may affect DMARC disposition or execution
+        thereof. -->
+   <xs:simpleType name="PolicyOverrideType">
+     <xs:restriction base="xs:string">
+       <xs:enumeration value="forwarded"/>
+       <xs:enumeration value="sampled_out"/>
+       <xs:enumeration value="trusted_forwarder"/>
+       <xs:enumeration value="mailing_list"/>
+       <xs:enumeration value="local_policy"/>
+       <xs:enumeration value="other"/>
+     </xs:restriction>
+   </xs:simpleType>
+
+   <!-- How do we allow report generators to include new
+        classes of override reasons if they want to be more
+        specific than "other"? -->
+   <xs:complexType name="PolicyOverrideReason">
+     <xs:all>
+       <xs:element name="type" type="PolicyOverrideType"/>
+       <xs:element name="comment" type="xs:string"
+                   minOccurs="0"/>
+     </xs:all>
+   </xs:complexType>
+
+   <!-- Taking into account everything else in the record,
+        the results of applying DMARC. -->
+   <xs:complexType name="PolicyEvaluatedType">
+     <xs:sequence>
+       <xs:element name="disposition" type="DispositionType"/>
+       <xs:element name="dkim" type="DMARCResultType"/>
+       <xs:element name="spf" type="DMARCResultType"/>
+       <xs:element name="reason" type="PolicyOverrideReason"
+                   minOccurs="0" maxOccurs="unbounded"/>
+     </xs:sequence>
+   </xs:complexType>
+
+   <!-- Credit to Roger L. Costello for IPv4 regex
+        http://mailman.ic.ac.uk/pipermail/xml-dev/1999-December/
+             018018.html -->
+   <!-- Credit to java2s.com for IPv6 regex
+        http://www.java2s.com/Code/XML/XML-Schema/
+             IPv6addressesareeasiertodescribeusingasimpleregex.htm -->
+   <xs:simpleType name="IPAddress">
+     <xs:restriction base="xs:string">
+       <xs:pattern value="((1?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]).){3}(1?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])|([A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}"/>
+     </xs:restriction>
+   </xs:simpleType>
+
+   <xs:complexType name="RowType">
+     <xs:all>
+       <!-- The connecting IP. -->
+       <xs:element name="source_ip" type="IPAddress"/>
+       <!-- The number of matching messages. -->
+       <xs:element name="count" type="xs:integer"/>
+       <!-- The DMARC disposition applying to matching
+            messages. -->
+       <xs:element name="policy_evaluated"
+                   type="PolicyEvaluatedType"
+                   minOccurs="1"/>
+     </xs:all>
+   </xs:complexType>
+
+   <xs:complexType name="IdentifierType">
+     <xs:all>
+       <!-- The envelope recipient domain. -->
+       <xs:element name="envelope_to" type="xs:string"
+                   minOccurs="0"/>
+       <!-- The RFC5321.MailFrom domain. -->
+       <xs:element name="envelope_from" type="xs:string"
+                   minOccurs="1"/>
+       <!-- The RFC5322.From domain. -->
+       <xs:element name="header_from" type="xs:string"
+                   minOccurs="1"/>
+     </xs:all>
+   </xs:complexType>
+
+   <!-- DKIM verification result, according to RFC 7001
+        Section 2.6.1. -->
+   <xs:simpleType name="DKIMResultType">
+     <xs:restriction base="xs:string">
+       <xs:enumeration value="none"/>
+       <xs:enumeration value="pass"/>
+       <xs:enumeration value="fail"/>
+       <xs:enumeration value="policy"/>
+       <xs:enumeration value="neutral"/>
+       <xs:enumeration value="temperror"/>
+       <xs:enumeration value="permerror"/>
+     </xs:restriction>
+   </xs:simpleType>
+
+   <xs:complexType name="DKIMAuthResultType">
+     <xs:all>
+       <!-- The "d=" parameter in the signature. -->
+       <xs:element name="domain" type="xs:string"
+                   minOccurs="1"/>
+       <!-- The "s=" parameter in the signature. -->
+       <xs:element name="selector" type="xs:string"
+                   minOccurs="0"/>
+       <!-- The DKIM verification result. -->
+       <xs:element name="result" type="DKIMResultType"
+                   minOccurs="1"/>
+       <!-- Any extra information (e.g., from
+            Authentication-Results). -->
+       <xs:element name="human_result" type="xs:string"
+                   minOccurs="0"/>
+     </xs:all>
+   </xs:complexType>
+
+   <!-- SPF domain scope. -->
+   <xs:simpleType name="SPFDomainScope">
+     <xs:restriction base="xs:string">
+       <xs:enumeration value="helo"/>
+       <xs:enumeration value="mfrom"/>
+     </xs:restriction>
+   </xs:simpleType>
+
+   <!-- SPF result. -->
+   <xs:simpleType name="SPFResultType">
+     <xs:restriction base="xs:string">
+       <xs:enumeration value="none"/>
+       <xs:enumeration value="neutral"/>
+       <xs:enumeration value="pass"/>
+       <xs:enumeration value="fail"/>
+       <xs:enumeration value="softfail"/>
+       <!-- "TempError" commonly implemented as "unknown". -->
+       <xs:enumeration value="temperror"/>
+       <!-- "PermError" commonly implemented as "error". -->
+       <xs:enumeration value="permerror"/>
+     </xs:restriction>
+   </xs:simpleType>
+
+   <xs:complexType name="SPFAuthResultType">
+     <xs:all>
+       <!-- The checked domain. -->
+       <xs:element name="domain" type="xs:string" minOccurs="1"/>
+       <!-- The scope of the checked domain. -->
+       <xs:element name="scope" type="SPFDomainScope" minOccurs="1"/>
+       <!-- The SPF verification result. -->
+       <xs:element name="result" type="SPFResultType"
+                   minOccurs="1"/>
+     </xs:all>
+   </xs:complexType>
+
+   <!-- This element contains DKIM and SPF results, uninterpreted
+        with respect to DMARC. -->
+   <xs:complexType name="AuthResultType">
+     <xs:sequence>
+       <!-- There may be no DKIM signatures, or multiple DKIM
+            signatures. -->
+       <xs:element name="dkim" type="DKIMAuthResultType"
+         minOccurs="0" maxOccurs="unbounded"/>
+       <!-- There will always be at least one SPF result. -->
+       <xs:element name="spf" type="SPFAuthResultType" minOccurs="1"
+                   maxOccurs="unbounded"/>
+     </xs:sequence>
+   </xs:complexType>
+
+   <!-- This element contains all the authentication results that
+        were evaluated by the receiving system for the given set of
+        messages. -->
+   <xs:complexType name="RecordType">
+     <xs:sequence>
+       <xs:element name="row" type="RowType"/>
+       <xs:element name="identifiers" type="IdentifierType"/>
+       <xs:element name="auth_results" type="AuthResultType"/>
+     </xs:sequence>
+   </xs:complexType>
+
+   <!-- Parent -->
+   <xs:element name="feedback">
+     <xs:complexType>
+       <xs:sequence>
+         <xs:element name="version"
+                     type="xs:decimal"/>
+         <xs:element name="report_metadata"
+                     type="ReportMetadataType"/>
+         <xs:element name="policy_published"
+                     type="PolicyPublishedType"/>
+         <xs:element name="record" type="RecordType"
+                     maxOccurs="unbounded"/>
+       </xs:sequence>
+     </xs:complexType>
+   </xs:element>
+ </xs:schema>


### PR DESCRIPTION
The elements in ReportMetaDataType in the schema are a sequence in a specified order, we are putting report_id in the wrong place.