### PR TITLE
Don't look in $PWD/lib, it breaks startup if $PWD is inaccessible

### DIFF
--- a/lib/Mail/DMARC/Report/Send.pm
+++ b/lib/Mail/DMARC/Report/Send.pm
@@ -3,7 +3,6 @@ package Mail::DMARC::Report::Send;
 use strict;
 use warnings;
 
-use lib 'lib';
 use parent 'Mail::DMARC::Base';
 use Mail::DMARC::Report::Send::SMTP;
 use Mail::DMARC::Report::Send::HTTP;


### PR DESCRIPTION
Don't look in $PWD/lib, it breaks startup if $PWD is inaccessible by the current user.
If a program starts in /root and then drops its privileges and changes its uid it won't access $PWD/lib.