### PR TITLE
Do not reject NXDOMAIN as per rfc

### DIFF
--- a/t/06.Result.t
+++ b/t/06.Result.t
@@ -172,8 +172,8 @@ SKIP: {
 
         is_deeply(
             $pp->result,
-            {   'result'      => 'fail',
-                'disposition' => 'reject',
+            {   'result'      => 'none',
+                'disposition' => 'none',
                 'dkim'        => '',
                 'spf'         => '',
                 'reason'      => [{
@@ -181,7 +181,7 @@ SKIP: {
                     'type'    => 'other',
                 }],
             },
-            "result, fail, nonexist"
+            "result, none, nonexist"
         ) or diag Data::Dumper::Dumper( $pp->result );
     }
 }


### PR DESCRIPTION
RFC7489 differs from the draft in the way that it handles non existent domains.  The draft called for a reject while the rfc calls for no action.  ref section 6.6.3

See Section A.4 of the RFC - Domain Existence Test....

The original pre-standardization version of this protocol included a
   mandatory check of this nature.  It was ultimately removed, as the
   method's error rate was too high without substantial manual tuning
   and heuristic work.  There are indeed use cases this work needs to
   address where such a method would return a negative result about a
   domain for which reporting is desired, such as a registered domain
   name that never sends legitimate mail and thus has none of these
   records present in the DNS.