### PR TITLE
use the first array element

### DIFF
--- a/t/17.Report.Aggregate.Schema.t
+++ b/t/17.Report.Aggregate.Schema.t
@@ -64,7 +64,7 @@ die 'Not using test store' if $store->{'SQL'}->{'config'}->{'report_store'}->{'d
 
 my $a = $store->{'SQL'}->query('UPDATE report SET begin=begin-86400, end=end-86400 WHERE id=1');
 
-my $agg = $store->retrieve_todo();
+my $agg = $store->retrieve_todo()->[0];
 
 test_against_schema();
 


### PR DESCRIPTION
to resolve this test error:

````
t/17.Report.Aggregate.Schema.t ............... Can't call method "metadata" on unblessed reference at t/17.Report.Aggregate.Schema.t line 76.
t/17.Report.Aggregate.Schema.t ............... Dubious, test returned 2 (wstat 512, 0x200)
No subtests run 
````