### PR TITLE
Use a larger integer type for `report_record`.`count`

### DIFF
--- a/share/mail_dmarc_schema.mysql
+++ b/share/mail_dmarc_schema.mysql
@@ -233,7 +233,7 @@ CREATE TABLE `report_record` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `report_id` int(11) unsigned NOT NULL,
   `source_ip` varbinary(16) NOT NULL DEFAULT '',
-  `count` tinyint(2) unsigned DEFAULT NULL,
+  `count` int(11) unsigned DEFAULT NULL,
   `disposition` varchar(10) NOT NULL DEFAULT '',
   `dkim` char(4) NOT NULL DEFAULT '',
   `spf` char(4) NOT NULL DEFAULT '',


### PR DESCRIPTION
Check commit message for details.

Tested successfully on our production systems. Unfortunately I cannot provide the test data as it's not something we'd like to share.

Related to https://github.com/msimerson/mail-dmarc/issues/100
