### PR TITLE
--geoip v6 support and field selection

### DIFF
--- a/bin/dmarc_view_reports
+++ b/bin/dmarc_view_reports
@@ -61,13 +61,14 @@ sub print_rows {
         next if $disposition && $disposition ne $row->{disposition};
         next if $dkim && $dkim ne $row->{dkim};
         next if $spf  && $spf ne $row->{spf};
-        my $dns_hostname = get_dns_hostname( $row->{source_ip} );
         printf "  | -- %3s %20s %39s %13s %7s %7s", @$row{qw/ count header_from source_ip disposition dkim spf /};
         foreach my $r ( @{ $row->{reasons} } ) {
             print '  ' . $r->{type};
             print "( $r->{comment} )" if $r->{comment};
         };
-        my $geoip = print_geoip( $row->{source_ip} );
+        my $geoip_details = get_geoip_details( $row->{source_ip} );
+        print " $geoip_details";
+        my $dns_hostname = get_dns_hostname( $row->{source_ip} );
         print "  $dns_hostname\n";
     }
     return;
@@ -79,7 +80,7 @@ sub print_header {
     return;
 };
 
-sub print_geoip {
+sub get_geoip_details {
     my $ip = shift;
     return if ! $geoip_opt;
     $gip ||= get_geoip_db();
@@ -90,21 +91,10 @@ sub print_geoip {
     my $country_name = $r->country_name();
     my $continent = $r->continent_code();
     my $city = $r->city;
-    print $city ?  " $city," : ' ';
-    print " $country_code, $continent";
-    return;
+
+    if ($city) { $city = "$city,"; }
+    return "$city $country_code, $continent"
 }
-
-sub get_dns_hostname {
-    my $ip = shift;
-    return if ! $dns_opt;
-
-    my @answers = $report->has_dns_rr('PTR', $ip);
-    return '' if 0 == scalar @answers;
-    return $answers[0] if scalar @answers >= 1;
-    print Dumper(\@answers);
-    return;
-};
 
 sub get_geoip_db {
 
@@ -129,6 +119,17 @@ sub get_geoip_db {
     };
     return $gip;
 }
+
+sub get_dns_hostname {
+    my $ip = shift;
+    return if ! $dns_opt;
+
+    my @answers = $report->has_dns_rr('PTR', $ip);
+    return '' if 0 == scalar @answers;
+    return $answers[0] if scalar @answers >= 1;
+    print Dumper(\@answers);
+    return;
+};
 
 exit;
 # PODNAME: dmarc_view_reports

--- a/bin/dmarc_view_reports
+++ b/bin/dmarc_view_reports
@@ -115,7 +115,8 @@ sub get_geoip_details {
 
     foreach my $f (@fields) {
        next if ! grep {$_ eq $f} @allowed;
-       push @result, $r->${f}() || '';
+       next if ! $r->${f}();
+       push @result, $r->${f}();
     }
 
     return join(', ', @result);

--- a/bin/dmarc_view_reports
+++ b/bin/dmarc_view_reports
@@ -3,7 +3,6 @@
 use strict;
 use warnings;
 
-use Net::IPv4Addr 'ipv4_chkip';
 use Data::Dumper;
 use Getopt::Long;
 use Pod::Usage;
@@ -90,7 +89,7 @@ sub get_geoip_details {
     $gip ||= get_geoip_db();
     return if ! $gip;
 
-    if (ipv4_chkip($ip)) {
+    if ($ip =~ /^\d+\.\d+\.\d+\.\d+$/) {
         $ip = '::ffff:'.$ip;
     }
 

--- a/bin/dmarc_view_reports
+++ b/bin/dmarc_view_reports
@@ -181,7 +181,7 @@ sub {}
 
   dmarc_view_reports [ --geoip --dns --help --verbose ]
 
-    geoip        - include GeoIP location (requires the free GeoCity Lite db)
+    geoip        - do GeoIP lookups (requires the free Maxmind GeoCityLitev6 database).
     dns          - do reverse DNS lookups and display hostnames
     help         - print this syntax guide
     verbose      - print additional debug info
@@ -193,6 +193,30 @@ To search for all reports from google.com that failed DMARC alignment:
   dmarc_view_reports --author=google.com --dkim=fail --spf=fail
 
 Note that we don't use --disposition. That would only tell us the result of applying DMARC policy, not necessarily if the messages failed DMARC alignment.
+
+To display GeoIP lookup data for the source ip:
+
+  dmarc_view_reports --geoip
+
+By default; city, country_code & continent_code are shown. You can optionally pass a comma delimited string to --geoip= with any of the following fields:
+
+country_code
+country_code3
+country_name
+region
+region_name
+city
+postal_code
+latitude
+longitude
+time_zone
+area_code
+continent_code
+metro_code
+
+  dmarc_view_reports --geoip=country_name,continent_code
+  dmarc_view_reports --geoip=continent_code,country_name # keep order
+  dmarc_view_reports --geoip=city,city,city              # repeat
 
 
 =head1 DESCRIPTION

--- a/bin/dmarc_view_reports
+++ b/bin/dmarc_view_reports
@@ -114,7 +114,7 @@ sub get_geoip_details {
     );
 
     foreach my $f (@fields) {
-       return if ! grep {$_ eq $f} @allowed;
+       next if ! grep {$_ eq $f} @allowed;
        push @result, $r->${f}() || '';
     }
 

--- a/bin/dmarc_view_reports
+++ b/bin/dmarc_view_reports
@@ -88,7 +88,6 @@ sub get_geoip_details {
 
     my $r = $gip->record_by_addr($ip) or return '';
     my $country_code = $r->country_code();
-    my $country_name = $r->country_name();
     my $continent = $r->continent_code();
     my $city = $r->city;
 

--- a/bin/dmarc_view_reports
+++ b/bin/dmarc_view_reports
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 
+use Net::IPv4Addr 'ipv4_chkip';
 use Data::Dumper;
 use Getopt::Long;
 use Pod::Usage;
@@ -17,10 +18,7 @@ my %command_line_options = (
     'dkim:s'        => \my $dkim,
     'spf:s'         => \my $spf,
     'dns'           => \my $dns_opt,
-    'geoip'         => \my $geoip_opt,
-    'geoip_country'   => \my $geoip_country_opt,
-    'geoip_city'      => \my $geoip_city_opt,
-    'geoip_continent' => \my $geoip_continent_opt,
+    'geoip:s'       => \my $geoip_opt,
     'help'          => \my $help,
     'verbose'       => \my $verbose,
     );
@@ -85,28 +83,43 @@ sub print_header {
 
 sub get_geoip_details {
     my $ip = shift;
-    if ($geoip_opt) {
-        $geoip_country_opt = 1;
-        $geoip_city_opt = 1;
-        $geoip_continent_opt = 1;
-    }
-    return if ! ($geoip_country_opt or $geoip_city_opt or $geoip_continent_opt);
+
+    return if ! defined $geoip_opt;
+    $geoip_opt ||= 'country_name';
+
     $gip ||= get_geoip_db();
     return if ! $gip;
 
-    my $r = $gip->record_by_addr($ip) or return '';
-    my $country_code = $r->country_code();
-    my $continent = $r->continent_code();
-    my $city = $r->city;
+    if (ipv4_chkip($ip)) {
+        $ip = '::ffff:'.$ip;
+    }
 
-    my $res;
-    if ($geoip_city_opt) { $res = "$city, " }
-    if ($geoip_country_opt) { $res .= "$country_code, " }
-    if ($geoip_continent_opt) { $res .= "$continent" }
+    my $r = $gip->record_by_addr_v6($ip) or return '';
 
-    $res =~ s/, $//;
+    my @result;
+    my @fields = split(',', $geoip_opt);
+    my @allowed = qw(
+	country_code
+	country_code3
+	country_name
+	region
+	region_name
+	city
+	postal_code
+	latitude
+	longitude
+	time_zone
+	area_code
+	continent_code
+	metro_code
+    );
 
-    return $res;
+    foreach my $f (@fields) {
+       return if ! grep {$_ eq $f} @allowed;
+       push @result, $r->${f}() || '';
+    }
+
+    return join(', ', @result);
 }
 
 sub get_geoip_db {
@@ -121,7 +134,7 @@ sub get_geoip_db {
     foreach my $local ( '/usr/local', '/opt/local', '/usr' ) {
         my $db_dir = "$local/share/GeoIP";
 
-        foreach my $db (qw/ GeoIPCity GeoLiteCity /) {
+        foreach my $db (qw/ GeoIPCityv6 GeoLiteCityv6 /) {
             if (-f "$db_dir/$db.dat") {
                 print "using db $db" if $verbose;
                 $gip = Geo::IP->open("$db_dir/$db.dat");

--- a/bin/dmarc_view_reports
+++ b/bin/dmarc_view_reports
@@ -18,6 +18,9 @@ my %command_line_options = (
     'spf:s'         => \my $spf,
     'dns'           => \my $dns_opt,
     'geoip'         => \my $geoip_opt,
+    'geoip_country'   => \my $geoip_country_opt,
+    'geoip_city'      => \my $geoip_city_opt,
+    'geoip_continent' => \my $geoip_continent_opt,
     'help'          => \my $help,
     'verbose'       => \my $verbose,
     );
@@ -82,7 +85,12 @@ sub print_header {
 
 sub get_geoip_details {
     my $ip = shift;
-    return if ! $geoip_opt;
+    if ($geoip_opt) {
+        $geoip_country_opt = 1;
+        $geoip_city_opt = 1;
+        $geoip_continent_opt = 1;
+    }
+    return if ! ($geoip_country_opt or $geoip_city_opt or $geoip_continent_opt);
     $gip ||= get_geoip_db();
     return if ! $gip;
 
@@ -91,8 +99,14 @@ sub get_geoip_details {
     my $continent = $r->continent_code();
     my $city = $r->city;
 
-    if ($city) { $city = "$city,"; }
-    return "$city $country_code, $continent"
+    my $res;
+    if ($geoip_city_opt) { $res = "$city, " }
+    if ($geoip_country_opt) { $res .= "$country_code, " }
+    if ($geoip_continent_opt) { $res .= "$continent" }
+
+    $res =~ s/, $//;
+
+    return $res;
 }
 
 sub get_geoip_db {

--- a/bin/dmarc_view_reports
+++ b/bin/dmarc_view_reports
@@ -84,7 +84,7 @@ sub get_geoip_details {
     my $ip = shift;
 
     return if ! defined $geoip_opt;
-    $geoip_opt ||= 'country_name';
+    $geoip_opt ||= 'city,country_code,continent_code';
 
     $gip ||= get_geoip_db();
     return if ! $gip;

--- a/bin/dmarc_view_reports
+++ b/bin/dmarc_view_reports
@@ -67,7 +67,7 @@ sub print_rows {
             print "( $r->{comment} )" if $r->{comment};
         };
         my $geoip_details = get_geoip_details( $row->{source_ip} );
-        print " $geoip_details";
+        print "  $geoip_details";
         my $dns_hostname = get_dns_hostname( $row->{source_ip} );
         print "  $dns_hostname\n";
     }

--- a/share/mail_dmarc_schema.mysql
+++ b/share/mail_dmarc_schema.mysql
@@ -233,7 +233,7 @@ CREATE TABLE `report_record` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `report_id` int(11) unsigned NOT NULL,
   `source_ip` varbinary(16) NOT NULL DEFAULT '',
-  `count` tinyint(2) unsigned DEFAULT NULL,
+  `count` int(11) unsigned DEFAULT NULL,
   `disposition` varchar(10) NOT NULL DEFAULT '',
   `dkim` char(4) NOT NULL DEFAULT '',
   `spf` char(4) NOT NULL DEFAULT '',


### PR DESCRIPTION
Check individual commit messages for details.

References #101.

While working on this I decided to change the initial `--geoip-*` flags idea. Rather than doing that, I now allow a string to be passed to `--geoip`, where the user can choose what fields to display and in what order.

I don't typically write Perl so let me know if there are weird constructs.

Tested on my production systems and it seems fine. Should be fairly easy to test on your systems if you just copy dmarc_view_reports into your home directory and run it with `./dmarc_view_reports`.