### PR TITLE
Ensure entities in XML agg reports are properly escaped

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Mail::DMARC - Perl implementation of DMARC
 
 # VERSION
 
-version 1.20160212
+version 1.20170206
 
 # SYNOPSIS
 
@@ -279,17 +279,19 @@ Qpsmtpd plugin: https://github.com/smtpd/qpsmtpd/blob/master/plugins/dmarc
 
 # AUTHORS
 
-- Matt Simerson &lt;msimerson@cpan.org>
-- Davide Migliavacca &lt;shari@cpan.org>
+- Matt Simerson <msimerson@cpan.org>
+- Davide Migliavacca <shari@cpan.org>
 
 # CONTRIBUTORS
 
-- Benny Pedersen &lt;me@junc.eu>
-- Making GitHub Delicious. &lt;iron@waffle.io>
-- Marc Bradshaw &lt;marc@marcbradshaw.net>
-- Priyadi Iman Nurcahyo &lt;priyadi@priyadi.net>
-- Ricardo Signes &lt;rjbs@cpan.org>
-- Ricardo Signes &lt;rjbs@users.noreply.github.com>
+- Benny Pedersen <me@junc.eu>
+- Jean Paul Galea <jeanpaul@yubico.com>
+- Jean Paul Galea <jp@galea.se>
+- Making GitHub Delicious. <iron@waffle.io>
+- Marc Bradshaw <marc@marcbradshaw.net>
+- Priyadi Iman Nurcahyo <priyadi@priyadi.net>
+- Ricardo Signes <rjbs@cpan.org>
+- Ricardo Signes <rjbs@users.noreply.github.com>
 
 # COPYRIGHT AND LICENSE
 

--- a/lib/Mail/DMARC/Report/Aggregate/Metadata.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Metadata.pm
@@ -2,6 +2,7 @@ package Mail::DMARC::Report::Aggregate::Metadata;
 # VERSION
 use strict;
 use warnings;
+use XML::LibXML;
 
 use parent 'Mail::DMARC::Base';
 
@@ -58,14 +59,18 @@ sub as_xml {
 
     foreach my $f (qw/ org_name email extra_contact_info report_id /) {
         my $val = $self->$f or next;
+        $val = XML::LibXML::Text->new( $val )->toString();
         $meta .= "\t\t<$f>$val</$f>\n";
     }
-    $meta .= "\t\t<date_range>\n\t\t\t<begin>" . $self->begin . "</begin>\n"
-          .  "\t\t\t<end>" . $self->end . "</end>\n\t\t</date_range>\n";
+    my $begin = XML::LibXML::Text->new( $self->begin )->toString();
+    my $end   = XML::LibXML::Text->new( $self->end )->toString();
+    $meta .= "\t\t<date_range>\n\t\t\t<begin>" . $begin . "</begin>\n"
+          .  "\t\t\t<end>" . $end . "</end>\n\t\t</date_range>\n";
 
     my $errors = $self->error;
     if ( $errors && @$errors ) {
         foreach my $err ( @$errors ) {
+            $err = XML::LibXML::Text->new( $err )->toString();
             $meta .= "\t\t<error>$err</error>\n";
         };
     };

--- a/t/17.Report.Aggregate.Schema.t
+++ b/t/17.Report.Aggregate.Schema.t
@@ -63,6 +63,7 @@ $store->{SQL}->config('t/mail-dmarc.ini');
 die 'Not using test store' if $store->{'SQL'}->{'config'}->{'report_store'}->{'dsn'} ne 'dbi:SQLite:dbname=:memory:';
 
 my $a = $store->{'SQL'}->query('UPDATE report SET begin=begin-86400, end=end-86400 WHERE id=1');
+   $a = $store->{'SQL'}->query('INSERT INTO report_error(report_id,error,time) VALUES(1,"<ERROR> Test error & encoding",100)');
 
 my $agg = $store->retrieve_todo()->[0];
 


### PR DESCRIPTION
Make sure any values included in the XML of an aggregate report are properly escaped.

Using XML::LibXML to avoid bringing in any additional dependencies. I would like eventually to rewrite this to use the methods of LibXML directly, but today is not that day.