### PR TITLE
calls to policy->parse no longer validate 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,46 +1,20 @@
 language: perl
 perl:
   - "5.20"
-  - "5.18"
-  - "5.16"
   - "5.14"
-  - "5.12"
   - "5.10"
 
-#branches:
-#  only:
-#    - releases
-
-# Travis: http://blogs.perl.org/users/alex_balhatchet/2013/04/travis-ci-perl.html
-
 before_install:
-   # Prevent "Please tell me who you are" errors for certain DZIL configs
-   - git config --global user.name "TravisCI"
-   - cpanm -n Devel::Cover::Report::Coveralls
 
 install:
    - cpanm --quiet --notest Regexp::Common Config::Tiny File::ShareDir Net::DNS::Resolver
    - cpanm --quiet --notest Net::IP Socket6 Email::MIME DBD::SQLite Net::SMTPS XML::LibXML
    - cpanm --quiet --notest DBIx::Simple HTTP::Tiny Test::File::ShareDir Test::Output
-   - cpanm --quiet --notest Net::IDN::Encode
+   - cpanm --quiet --notest Net::IDN::Encode CGI
 
-   # Deal with all of the DZIL dependencies, quickly and quietly
-#  - cpanm --quiet --notest --skip-satisfied Dist::Zilla
-#  - cpanm --quiet --notest --skip-satisfied Pod::Weaver::Section::Contributors
-#  - cpanm --quiet --notest --skip-satisfied Pod::Coverage::TrustPod
-#  - cpanm --quiet --notest --skip-satisfied Test::Pod::Coverage
-#
-#  - dzil authordeps | grep -vP '[^\w:]' | xargs -n 5 -P 10 cpanm --quiet --notest --skip-satisfied
-#
-#  - export RELEASE_TESTING=1 AUTOMATED_TESTING=1 AUTHOR_TESTING=1 HARNESS_OPTIONS=j10:c HARNESS_TIMER=1
-#
-#  - dzil listdeps | grep -vP '[^\w:]' | cpanm --verbose
-#
-# using Socket6 instead, no need to force this upgrade
-#  - cpanm --quiet --notest --skip-satisfied 'Socket~2'
-#
-script: HARNESS_IS_VERBOSE=1 prove -v -Ilib t
-#
-#   - dzil smoke --release --author
-after_script:
+script:
+   - HARNESS_IS_VERBOSE=1 prove -v -Ilib t
+
+after_success:
+  - cpanm -n Devel::Cover::Report::Coveralls
   - cover -test -make 'prove -Ilib t' -report coveralls

--- a/Changes
+++ b/Changes
@@ -1,7 +1,18 @@
 
 {{$NEXT}}
 
+ - Ensure entities in XML agg reports are properly escaped #104
+ - geoip v6 support and field selection #103
+ - use a larger integer type for report_record.count #102
+ - improved apt package lookups in install_deps.pl #98
+
 1.20160612 2016-06-11 America/Los_Angeles
+
+ - fix aggregrate schema test #96
+ - Do not reject NXDOMAIN as per rfc #94
+ - added none result for no policy #93
+ - avoid deadlock with some invalid rua data #92
+ - avoid loop when sending reports via http #92
 
 1.20150908 2015-09-08 America/Los_Angeles
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,27 +3,27 @@
 
 ## The fast way, using your systems package manager (yum, apt, ports):
 
-   perl bin/install_deps.pl
+    perl bin/install_deps.pl
 
 If your system doesn't have a package manager, or the package version fails, or the version installed by your systems package manager isn't new enough, install_deps will also attempt to install the latest version via CPAN.
 
 Once the dependencies are installed, install Mail::DMARC as any other perl module:
 
-   perl Makefile.PL
-   make
-   make install clean
+    perl Makefile.PL
+    make
+    make install clean
 
 Copy the mail-dmarc.ini file to your systems preferred local etc directory (/etc, /usr/local/etc, opt/local/etc) and edit at least the settings in the [organization] block:
 
-   cp mail-dmarc.ini /etc/
-   $EDITOR /etc/mail-dmarc.ini
+    cp mail-dmarc.ini /etc/
+    $EDITOR /etc/mail-dmarc.ini
 
 NOTE: Most of the dependencies are optionally required for the DMARC reporting features. Mail::DMARC will perform validation with only these modules:
 
-   Regexp::Common
-   Config::Tiny
-   File::ShareDir
-   Net::DNS::Resolver
-   Net::IP
-   Socket6
+    Regexp::Common
+    Config::Tiny
+    File::ShareDir
+    Net::DNS::Resolver
+    Net::IP
+    Socket6
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,6 @@ The report store can use the same database to store reports you have received as
 
 [![Coverage Status](https://coveralls.io/repos/msimerson/mail-dmarc/badge.svg)](https://coveralls.io/r/msimerson/mail-dmarc)
 
-[![Stories in Ready](https://badge.waffle.io/msimerson/mail-dmarc.png?label=ready&title=Ready)](https://waffle.io/msimerson/mail-dmarc)
-
 # CLASSES
 
 [Mail::DMARC](https://metacpan.org/pod/Mail::DMARC) - the perl interface for DMARC
@@ -243,19 +241,19 @@ The SPF result code: none, neutral, pass, fail, softfail, temperror, or permerro
 
 ## Correct
 
-The DMARC spec is lengthy and evolving, making correctness a moving target. In cases where correctness is ambiguous, options are generally provided.
+In cases where correctness is ambiguous, options are provided.
 
 ## Easy to use
 
-The effectiveness of DMARC will improve significantly as adoption increases. Proving an implementation of DMARC that SMTP utilities like SpamAssassin, amavis, and qpsmtpd can consume will aid adoption.
+Providing an implementation of DMARC that SMTP utilities like SpamAssassin, amavis, and qpsmtpd can consume is expected to increase adoption.
 
 The list of dependencies appears long because of reporting. If this module is used without reporting, the number of dependencies not included with perl is about 5. See the \[Prereq\] versus \[Prereq / Recommends\] sections in dist.ini.
 
 ## Maintainable
 
-Since DMARC is evolving, this implementation aims to be straight forward and dare I say, easy, to alter and extend. The programming style is primarily OO, which carries a small performance penalty but large dividends in maintainability.
+This implementation aims to be straight forward and easy to alter and extend. The programming style is primarily OO, which carries a small performance penalty but large dividends in maintainability.
 
-When multiple options are available, such as when sending reports via SMTP or HTTP, calls should be made to the parent Send class, to broker the request. When storing reports, calls are made to the Store class, which dispatches to the SQL class. The idea is that if someone desired a data store other than the many provided by perl's DBI class, they could easily implement their own. If you do, please fork it on GitHub and share.
+When multiple options are available, such as when sending reports via SMTP or HTTP, calls should be made to the parent Send class, to broker the request. When storing reports, calls are made to the Store class, which dispatches to the SQL class. The idea is that if someone desired a data store other than those provided by perl's DBI class, they could easily implement their own. If you do, please fork it on GitHub and share.
 
 ## Fast
 
@@ -263,19 +261,17 @@ If you deploy this in an environment where performance is insufficient, please p
 
 # SEE ALSO
 
-Mail::DMARC on GitHub: https://github.com/msimerson/mail-dmarc
+Mail::DMARC on [GitHub](https://github.com/msimerson/mail-dmarc)
 
-Mar 13, 2013 Draft: http://tools.ietf.org/html/draft-kucherawy-dmarc-base-00
+2015-03: [RFC 7489](https://tools.ietf.org/html/rfc7489)
 
-Mar 30, 2012 Draft: http://www.dmarc.org/draft-dmarc-base-00-02.txt
-
-Best Current Practices: http://tools.ietf.org/html/draft-crocker-dmarc-bcp-03
+DMARC [Best Current Practices](http://tools.ietf.org/html/draft-crocker-dmarc-bcp-03)
 
 # HISTORY
 
 The daddy of this perl module was a DMARC module for the qpsmtpd MTA.
 
-Qpsmtpd plugin: https://github.com/smtpd/qpsmtpd/blob/master/plugins/dmarc
+[Qpsmtpd plugin](https://github.com/smtpd/qpsmtpd/blob/master/plugins/dmarc)
 
 # AUTHORS
 
@@ -285,17 +281,15 @@ Qpsmtpd plugin: https://github.com/smtpd/qpsmtpd/blob/master/plugins/dmarc
 # CONTRIBUTORS
 
 - Benny Pedersen <me@junc.eu>
+- ColocateUSA.net <company@colocateusa.net>
 - Jean Paul Galea <jeanpaul@yubico.com>
-- Jean Paul Galea <jp@galea.se>
-- Making GitHub Delicious. <iron@waffle.io>
 - Marc Bradshaw <marc@marcbradshaw.net>
 - Priyadi Iman Nurcahyo <priyadi@priyadi.net>
 - Ricardo Signes <rjbs@cpan.org>
-- Ricardo Signes <rjbs@users.noreply.github.com>
 
 # COPYRIGHT AND LICENSE
 
-This software is copyright (c) 2015 by Matt Simerson.
+This software is copyright (c) 2017 by Matt Simerson.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Mail::DMARC - Perl implementation of DMARC
 
 # VERSION
 
-version 1.20170206
+version 1.20170220
 
 # SYNOPSIS
 

--- a/bin/dmarc_send_reports
+++ b/bin/dmarc_send_reports
@@ -121,14 +121,14 @@ sub send_single_report {
     my $bytes  = length Encode::encode_utf8($shrunk);
 
     my $uri_ref;
-    eval{
-      $uri_ref = $report->uri->parse( $aggregate->policy_published->rua );
+    eval {
+        $uri_ref = $report->uri->parse( $aggregate->policy_published->rua );
     };
     if ( my $error = $@ ) {
-       print "No valid ruas found, deleting report\n";
-       log_to_syslog({
+        print "No valid ruas found, deleting report\n";
+        log_to_syslog({
             'id'    =>  $aggregate->metadata->report_id,
-            'error' => 'No valid ruas found - deleting reporti - ' . $error,
+            'error' => 'No valid ruas found - deleting report - ' . $error,
         });
         $report->store->delete_report($aggregate->metadata->report_id);
         alarm(0);
@@ -136,8 +136,8 @@ sub send_single_report {
     }
 
     if ( scalar @{ $uri_ref } == 0 ) {
-       print "No valid ruas found, deleting report\n";
-       log_to_syslog({
+        print "No valid ruas found, deleting report\n";
+        log_to_syslog({
             'id'    =>  $aggregate->metadata->report_id,
             'error' => 'No valid ruas found - deleting report',
         });
@@ -155,7 +155,6 @@ sub send_single_report {
         my $max    = $u_ref->{max_bytes};
 
         if ( $max && $bytes > $max ) {
-# TODO: try compressing the report with gzip -9 ?
            log_to_syslog({
                 'id'   => $aggregate->metadata->report_id,
                 "info' => 'skipping $method: report size ($bytes) larger than $max",
@@ -191,6 +190,7 @@ sub send_single_report {
     };
 
     alarm(0);
+    return;
 }
 
 sub send_too_big_email {

--- a/lib/Mail/DMARC.pm
+++ b/lib/Mail/DMARC.pm
@@ -130,6 +130,7 @@ sub _from_mail_dkim {
                 human_result => $s->result_detail,
             );
     }
+    return;
 }
 
 sub _unwrap {
@@ -274,6 +275,7 @@ sub init {
     # used for testing
     my $self = shift;
     map { delete $self->{$_} } qw/ spf spf_ar dkim dkim_ar /;
+    return;
 }
 
 1;
@@ -287,7 +289,6 @@ __END__
 
 =for markdown [![Coverage Status](https://coveralls.io/repos/msimerson/mail-dmarc/badge.svg)](https://coveralls.io/r/msimerson/mail-dmarc)
 
-=for markdown [![Stories in Ready](https://badge.waffle.io/msimerson/mail-dmarc.png?label=ready&title=Ready)](https://waffle.io/msimerson/mail-dmarc)
 
 =head1 SYNOPSIS
 

--- a/lib/Mail/DMARC/Base.pm
+++ b/lib/Mail/DMARC/Base.pm
@@ -93,7 +93,7 @@ sub any_inet_pton {
     sub get_public_suffix_list {
         my ( $self ) = @_;
         if ( $public_suffixes ) { return $public_suffixes; }
-        no warnings 'once';
+        no warnings 'once';  ## no critic
         $Mail::DMARC::psl_loads++;
         my $file = $self->find_psl_file();
         $public_suffixes_stamp = ( stat( $file ) )[9];
@@ -103,7 +103,7 @@ sub any_inet_pton {
         # load PSL into hash for fast lookups, esp. for long running daemons
         my %psl = map { $_ => 1 }
                   grep { $_ !~ /^[\/\s]/ } # weed out comments & whitespace
-                  map { chomp($_); $_ }    # remove line endings
+                  map { chomp($_); $_ }    ## no critic, remove line endings
                   <$fh>;
         close $fh;
         return $public_suffixes = \%psl;
@@ -170,6 +170,7 @@ sub update_psl_file {
             print "Public Suffix List file $psl_file updated\n";
         }
     }
+    return;
 }
 
 sub find_psl_file {
@@ -182,7 +183,7 @@ sub find_psl_file {
         return $file;
     }
     my $path;
-    foreach $path ($self->get_prefix('share/' . $file)) {
+    foreach $path ($self->get_prefix('share/' . $file)) {    ## no critic
         last if ( -f $path && -r $path );
     }
     if ($path && -r $path) {
@@ -247,6 +248,7 @@ sub get_resolver {
 sub set_resolver {
     my ($self,$resolver) = @_;
     $self->{resolver} = $resolver;
+    return;
 }
 
 sub is_valid_ip {

--- a/lib/Mail/DMARC/Policy.pm
+++ b/lib/Mail/DMARC/Policy.pm
@@ -13,7 +13,11 @@ sub new {
     my $self = bless {}, $package;
 
     return $self if 0 == scalar @args;                # no args, empty pol
-    return $self->parse( $args[0] ) if 1 == @args;    # a string
+    if (1 == @args) {                                 # a string
+        my $policy = $self->parse( $args[0] );
+        $self->is_valid($policy);
+        return $policy;
+    }
 
     croak "invalid arguments" if @args % 2 != 0;
     my $policy = {@args};
@@ -48,7 +52,6 @@ sub parse {
         }
         $policy{$tag} = $value;
     }
-    croak "invalid policy" if !$self->is_valid(\%policy);
     return bless \%policy, ref $self;    # inherited defaults + overrides
 }
 
@@ -256,6 +259,7 @@ via DNS.
 
     my $pol = Mail::DMARC::Policy->new;
     $pol->parse( 'v=DMARC1; p=none; rua=mailto:dmarc@example.com' );
+    $pol->parse( 'v=DMARC1' );       # external reporting record
 
 =head1 Record Tags
 

--- a/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/DKIM.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/DKIM.pm
@@ -69,6 +69,7 @@ sub is_valid {
             croak "DKIM value $f is required!";
         }
     }
+    return;
 }
 
 1;

--- a/share/public_suffix_list
+++ b/share/public_suffix_list
@@ -1,10 +1,15 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Please pull this list from, and only from https://publicsuffix.org/list/public_suffix_list.dat,
+// rather than any other VCS sites. Pulling from any other URL is not guaranteed to be supported.
+
+// Instructions on pulling and using this list can be found at https://publicsuffix.org/list/.
 
 // ===BEGIN ICANN DOMAINS===
 
-// ac : http://en.wikipedia.org/wiki/.ac
+// ac : https://en.wikipedia.org/wiki/.ac
 ac
 com.ac
 edu.ac
@@ -13,11 +18,11 @@ net.ac
 mil.ac
 org.ac
 
-// ad : http://en.wikipedia.org/wiki/.ad
+// ad : https://en.wikipedia.org/wiki/.ad
 ad
 nom.ad
 
-// ae : http://en.wikipedia.org/wiki/.ae
+// ae : https://en.wikipedia.org/wiki/.ae
 // see also: "Domain Name Eligibility Policy" at http://www.aeda.ae/eng/aepolicy.php
 ae
 co.ae
@@ -28,7 +33,7 @@ ac.ae
 gov.ae
 mil.ae
 
-// aero : see http://www.information.aero/index.php?id=66
+// aero : see https://www.information.aero/index.php?id=66
 aero
 accident-investigation.aero
 accident-prevention.aero
@@ -89,7 +94,6 @@ leasing.aero
 logistics.aero
 magazine.aero
 maintenance.aero
-marketplace.aero
 media.aero
 microlight.aero
 modelling.aero
@@ -112,7 +116,6 @@ show.aero
 skydiving.aero
 software.aero
 student.aero
-taxi.aero
 trader.aero
 trading.aero
 trainer.aero
@@ -152,17 +155,10 @@ mil.al
 net.al
 org.al
 
-// am : http://en.wikipedia.org/wiki/.am
+// am : https://en.wikipedia.org/wiki/.am
 am
 
-// an : http://www.una.an/an_domreg/default.asp
-an
-com.an
-net.an
-org.an
-edu.an
-
-// ao : http://en.wikipedia.org/wiki/.ao
+// ao : https://en.wikipedia.org/wiki/.ao
 // http://www.dns.ao/REGISTR.DOC
 ao
 ed.ao
@@ -172,7 +168,7 @@ co.ao
 pb.ao
 it.ao
 
-// aq : http://en.wikipedia.org/wiki/.aq
+// aq : https://en.wikipedia.org/wiki/.aq
 aq
 
 // ar : https://nic.ar/normativa-vigente.xhtml
@@ -187,7 +183,7 @@ net.ar
 org.ar
 tur.ar
 
-// arpa : http://en.wikipedia.org/wiki/.arpa
+// arpa : https://en.wikipedia.org/wiki/.arpa
 // Confirmed by registry <iana-questions@icann.org> 2008-06-18
 arpa
 e164.arpa
@@ -197,14 +193,14 @@ iris.arpa
 uri.arpa
 urn.arpa
 
-// as : http://en.wikipedia.org/wiki/.as
+// as : https://en.wikipedia.org/wiki/.as
 as
 gov.as
 
-// asia : http://en.wikipedia.org/wiki/.asia
+// asia : https://en.wikipedia.org/wiki/.asia
 asia
 
-// at : http://en.wikipedia.org/wiki/.at
+// at : https://en.wikipedia.org/wiki/.at
 // Confirmed by registry <it@nic.at> 2008-06-17
 at
 ac.at
@@ -212,7 +208,7 @@ co.at
 gv.at
 or.at
 
-// au : http://en.wikipedia.org/wiki/.au
+// au : https://en.wikipedia.org/wiki/.au
 // http://www.auda.org.au/
 au
 // 2LDs
@@ -254,14 +250,14 @@ tas.gov.au
 vic.gov.au
 wa.gov.au
 
-// aw : http://en.wikipedia.org/wiki/.aw
+// aw : https://en.wikipedia.org/wiki/.aw
 aw
 com.aw
 
-// ax : http://en.wikipedia.org/wiki/.ax
+// ax : https://en.wikipedia.org/wiki/.ax
 ax
 
-// az : http://en.wikipedia.org/wiki/.az
+// az : https://en.wikipedia.org/wiki/.az
 az
 com.az
 net.az
@@ -276,20 +272,16 @@ name.az
 pro.az
 biz.az
 
-// ba : http://en.wikipedia.org/wiki/.ba
+// ba : http://nic.ba/users_data/files/pravilnik_o_registraciji.pdf
 ba
-org.ba
-net.ba
+com.ba
 edu.ba
 gov.ba
 mil.ba
-unsa.ba
-unbi.ba
-co.ba
-com.ba
-rs.ba
+net.ba
+org.ba
 
-// bb : http://en.wikipedia.org/wiki/.bb
+// bb : https://en.wikipedia.org/wiki/.bb
 bb
 biz.bb
 co.bb
@@ -302,19 +294,19 @@ org.bb
 store.bb
 tv.bb
 
-// bd : http://en.wikipedia.org/wiki/.bd
+// bd : https://en.wikipedia.org/wiki/.bd
 *.bd
 
-// be : http://en.wikipedia.org/wiki/.be
+// be : https://en.wikipedia.org/wiki/.be
 // Confirmed by registry <tech@dns.be> 2008-06-08
 be
 ac.be
 
-// bf : http://en.wikipedia.org/wiki/.bf
+// bf : https://en.wikipedia.org/wiki/.bf
 bf
 gov.bf
 
-// bg : http://en.wikipedia.org/wiki/.bg
+// bg : https://en.wikipedia.org/wiki/.bg
 // https://www.register.bg/user/static/rules/en/index.html
 bg
 a.bg
@@ -354,7 +346,7 @@ z.bg
 8.bg
 9.bg
 
-// bh : http://en.wikipedia.org/wiki/.bh
+// bh : https://en.wikipedia.org/wiki/.bh
 bh
 com.bh
 edu.bh
@@ -362,7 +354,7 @@ net.bh
 org.bh
 gov.bh
 
-// bi : http://en.wikipedia.org/wiki/.bi
+// bi : https://en.wikipedia.org/wiki/.bi
 // http://whois.nic.bi/
 bi
 co.bi
@@ -371,10 +363,10 @@ edu.bi
 or.bi
 org.bi
 
-// biz : http://en.wikipedia.org/wiki/.biz
+// biz : https://en.wikipedia.org/wiki/.biz
 biz
 
-// bj : http://en.wikipedia.org/wiki/.bj
+// bj : https://en.wikipedia.org/wiki/.bj
 bj
 asso.bj
 barreau.bj
@@ -388,7 +380,7 @@ gov.bm
 net.bm
 org.bm
 
-// bn : http://en.wikipedia.org/wiki/.bn
+// bn : https://en.wikipedia.org/wiki/.bn
 *.bn
 
 // bo : http://www.nic.bo/
@@ -404,7 +396,7 @@ mil.bo
 tv.bo
 
 // br : http://registro.br/dominio/categoria.html
-// Submitted by registry <fneves@registro.br> 2014-08-11
+// Submitted by registry <fneves@registro.br>
 br
 adm.br
 adv.br
@@ -485,7 +477,7 @@ org.bs
 edu.bs
 gov.bs
 
-// bt : http://en.wikipedia.org/wiki/.bt
+// bt : https://en.wikipedia.org/wiki/.bt
 bt
 com.bt
 edu.bt
@@ -494,17 +486,17 @@ net.bt
 org.bt
 
 // bv : No registrations at this time.
-// Submitted by registry <jarle@uninett.no> 2006-06-16
+// Submitted by registry <jarle@uninett.no>
 bv
 
-// bw : http://en.wikipedia.org/wiki/.bw
+// bw : https://en.wikipedia.org/wiki/.bw
 // http://www.gobin.info/domainname/bw.doc
 // list of other 2nd level tlds ?
 bw
 co.bw
 org.bw
 
-// by : http://en.wikipedia.org/wiki/.by
+// by : https://en.wikipedia.org/wiki/.by
 // http://tld.by/rules_2006_en.html
 // list of other 2nd level tlds ?
 by
@@ -518,7 +510,7 @@ com.by
 // http://hoster.by/
 of.by
 
-// bz : http://en.wikipedia.org/wiki/.bz
+// bz : https://en.wikipedia.org/wiki/.bz
 // http://www.belizenic.bz/
 bz
 com.bz
@@ -527,7 +519,7 @@ org.bz
 edu.bz
 gov.bz
 
-// ca : http://en.wikipedia.org/wiki/.ca
+// ca : https://en.wikipedia.org/wiki/.ca
 ca
 // ca geographical names
 ab.ca
@@ -544,31 +536,31 @@ pe.ca
 qc.ca
 sk.ca
 yk.ca
-// gc.ca: http://en.wikipedia.org/wiki/.gc.ca
+// gc.ca: https://en.wikipedia.org/wiki/.gc.ca
 // see also: http://registry.gc.ca/en/SubdomainFAQ
 gc.ca
 
-// cat : http://en.wikipedia.org/wiki/.cat
+// cat : https://en.wikipedia.org/wiki/.cat
 cat
 
-// cc : http://en.wikipedia.org/wiki/.cc
+// cc : https://en.wikipedia.org/wiki/.cc
 cc
 
-// cd : http://en.wikipedia.org/wiki/.cd
+// cd : https://en.wikipedia.org/wiki/.cd
 // see also: https://www.nic.cd/domain/insertDomain_2.jsp?act=1
 cd
 gov.cd
 
-// cf : http://en.wikipedia.org/wiki/.cf
+// cf : https://en.wikipedia.org/wiki/.cf
 cf
 
-// cg : http://en.wikipedia.org/wiki/.cg
+// cg : https://en.wikipedia.org/wiki/.cg
 cg
 
-// ch : http://en.wikipedia.org/wiki/.ch
+// ch : https://en.wikipedia.org/wiki/.ch
 ch
 
-// ci : http://en.wikipedia.org/wiki/.ci
+// ci : https://en.wikipedia.org/wiki/.ci
 // http://www.nic.ci/index.php?page=charte
 ci
 org.ci
@@ -587,26 +579,26 @@ presse.ci
 md.ci
 gouv.ci
 
-// ck : http://en.wikipedia.org/wiki/.ck
+// ck : https://en.wikipedia.org/wiki/.ck
 *.ck
 !www.ck
 
-// cl : http://en.wikipedia.org/wiki/.cl
+// cl : https://en.wikipedia.org/wiki/.cl
 cl
 gov.cl
 gob.cl
 co.cl
 mil.cl
 
-// cm : http://en.wikipedia.org/wiki/.cm plus bug 981927
+// cm : https://en.wikipedia.org/wiki/.cm plus bug 981927
 cm
 co.cm
 com.cm
 gov.cm
 net.cm
 
-// cn : http://en.wikipedia.org/wiki/.cn
-// Submitted by registry <tanyaling@cnnic.cn> 2008-06-11
+// cn : https://en.wikipedia.org/wiki/.cn
+// Submitted by registry <tanyaling@cnnic.cn>
 cn
 ac.cn
 com.cn
@@ -654,8 +646,8 @@ hk.cn
 mo.cn
 tw.cn
 
-// co : http://en.wikipedia.org/wiki/.co
-// Submitted by registry <tecnico@uniandes.edu.co> 2008-06-11
+// co : https://en.wikipedia.org/wiki/.co
+// Submitted by registry <tecnico@uniandes.edu.co>
 co
 arts.co
 com.co
@@ -671,10 +663,10 @@ org.co
 rec.co
 web.co
 
-// com : http://en.wikipedia.org/wiki/.com
+// com : https://en.wikipedia.org/wiki/.com
 com
 
-// coop : http://en.wikipedia.org/wiki/.coop
+// coop : https://en.wikipedia.org/wiki/.coop
 coop
 
 // cr : http://www.nic.cr/niccr_publico/showRegistroDominiosScreen.do
@@ -687,7 +679,7 @@ go.cr
 or.cr
 sa.cr
 
-// cu : http://en.wikipedia.org/wiki/.cu
+// cu : https://en.wikipedia.org/wiki/.cu
 cu
 com.cu
 edu.cu
@@ -696,7 +688,7 @@ net.cu
 gov.cu
 inf.cu
 
-// cv : http://en.wikipedia.org/wiki/.cv
+// cv : https://en.wikipedia.org/wiki/.cv
 cv
 
 // cw : http://www.una.cw/cw_registry/
@@ -707,12 +699,14 @@ edu.cw
 net.cw
 org.cw
 
-// cx : http://en.wikipedia.org/wiki/.cx
+// cx : https://en.wikipedia.org/wiki/.cx
 // list of other 2nd level tlds ?
 cx
 gov.cx
 
-// cy : http://en.wikipedia.org/wiki/.cy
+// cy : http://www.nic.cy/
+// Submitted by registry Panayiotou Fotia <cydns@ucy.ac.cy>
+cy
 ac.cy
 biz.cy
 com.cy
@@ -727,22 +721,22 @@ press.cy
 pro.cy
 tm.cy
 
-// cz : http://en.wikipedia.org/wiki/.cz
+// cz : https://en.wikipedia.org/wiki/.cz
 cz
 
-// de : http://en.wikipedia.org/wiki/.de
+// de : https://en.wikipedia.org/wiki/.de
 // Confirmed by registry <ops@denic.de> (with technical
 // reservations) 2008-07-01
 de
 
-// dj : http://en.wikipedia.org/wiki/.dj
+// dj : https://en.wikipedia.org/wiki/.dj
 dj
 
-// dk : http://en.wikipedia.org/wiki/.dk
+// dk : https://en.wikipedia.org/wiki/.dk
 // Confirmed by registry <robert@dk-hostmaster.dk> 2008-06-17
 dk
 
-// dm : http://en.wikipedia.org/wiki/.dm
+// dm : https://en.wikipedia.org/wiki/.dm
 dm
 com.dm
 net.dm
@@ -750,7 +744,7 @@ org.dm
 edu.dm
 gov.dm
 
-// do : http://en.wikipedia.org/wiki/.do
+// do : https://en.wikipedia.org/wiki/.do
 do
 art.do
 com.do
@@ -763,7 +757,7 @@ org.do
 sld.do
 web.do
 
-// dz : http://en.wikipedia.org/wiki/.dz
+// dz : https://en.wikipedia.org/wiki/.dz
 dz
 com.dz
 org.dz
@@ -775,7 +769,7 @@ pol.dz
 art.dz
 
 // ec : http://www.nic.ec/reg/paso1.asp
-// Submitted by registry <vabboud@nic.ec> 2008-07-04
+// Submitted by registry <vabboud@nic.ec>
 ec
 com.ec
 info.ec
@@ -790,7 +784,7 @@ gov.ec
 gob.ec
 mil.ec
 
-// edu : http://en.wikipedia.org/wiki/.edu
+// edu : https://en.wikipedia.org/wiki/.edu
 edu
 
 // ee : http://www.eenet.ee/EENet/dom_reeglid.html#lisa_B
@@ -806,7 +800,7 @@ aip.ee
 org.ee
 fie.ee
 
-// eg : http://en.wikipedia.org/wiki/.eg
+// eg : https://en.wikipedia.org/wiki/.eg
 eg
 com.eg
 edu.eg
@@ -818,7 +812,7 @@ net.eg
 org.eg
 sci.eg
 
-// er : http://en.wikipedia.org/wiki/.er
+// er : https://en.wikipedia.org/wiki/.er
 *.er
 
 // es : https://www.nic.es/site_ingles/ingles/dominios/index.html
@@ -829,7 +823,7 @@ org.es
 gob.es
 edu.es
 
-// et : http://en.wikipedia.org/wiki/.et
+// et : https://en.wikipedia.org/wiki/.et
 et
 com.et
 gov.et
@@ -840,28 +834,28 @@ name.et
 info.et
 net.et
 
-// eu : http://en.wikipedia.org/wiki/.eu
+// eu : https://en.wikipedia.org/wiki/.eu
 eu
 
-// fi : http://en.wikipedia.org/wiki/.fi
+// fi : https://en.wikipedia.org/wiki/.fi
 fi
-// aland.fi : http://en.wikipedia.org/wiki/.ax
+// aland.fi : https://en.wikipedia.org/wiki/.ax
 // This domain is being phased out in favor of .ax. As there are still many
 // domains under aland.fi, we still keep it on the list until aland.fi is
 // completely removed.
 // TODO: Check for updates (expected to be phased out around Q1/2009)
 aland.fi
 
-// fj : http://en.wikipedia.org/wiki/.fj
+// fj : https://en.wikipedia.org/wiki/.fj
 *.fj
 
-// fk : http://en.wikipedia.org/wiki/.fk
+// fk : https://en.wikipedia.org/wiki/.fk
 *.fk
 
-// fm : http://en.wikipedia.org/wiki/.fm
+// fm : https://en.wikipedia.org/wiki/.fm
 fm
 
-// fo : http://en.wikipedia.org/wiki/.fo
+// fo : https://en.wikipedia.org/wiki/.fo
 fo
 
 // fr : http://www.afnic.fr/
@@ -892,14 +886,14 @@ pharmacien.fr
 port.fr
 veterinaire.fr
 
-// ga : http://en.wikipedia.org/wiki/.ga
+// ga : https://en.wikipedia.org/wiki/.ga
 ga
 
 // gb : This registry is effectively dormant
-// Submitted by registry <Damien.Shaw@ja.net> 2008-06-12
+// Submitted by registry <Damien.Shaw@ja.net>
 gb
 
-// gd : http://en.wikipedia.org/wiki/.gd
+// gd : https://en.wikipedia.org/wiki/.gd
 gd
 
 // ge : http://www.nic.net.ge/policy_en.pdf
@@ -912,7 +906,7 @@ mil.ge
 net.ge
 pvt.ge
 
-// gf : http://en.wikipedia.org/wiki/.gf
+// gf : https://en.wikipedia.org/wiki/.gf
 gf
 
 // gg : http://www.channelisles.net/register-domains/
@@ -922,7 +916,7 @@ co.gg
 net.gg
 org.gg
 
-// gh : http://en.wikipedia.org/wiki/.gh
+// gh : https://en.wikipedia.org/wiki/.gh
 // see also: http://www.nic.gh/reg_now.php
 // Although domains directly at second level are not possible at the moment,
 // they have been possible for some time and may come back.
@@ -942,7 +936,7 @@ mod.gi
 edu.gi
 org.gi
 
-// gl : http://en.wikipedia.org/wiki/.gl
+// gl : https://en.wikipedia.org/wiki/.gl
 // http://nic.gl
 gl
 co.gl
@@ -955,7 +949,7 @@ org.gl
 gm
 
 // gn : http://psg.com/dns/gn/gn.txt
-// Submitted by registry <randy@psg.com> 2008-06-17
+// Submitted by registry <randy@psg.com>
 gn
 ac.gn
 com.gn
@@ -964,7 +958,7 @@ gov.gn
 org.gn
 net.gn
 
-// gov : http://en.wikipedia.org/wiki/.gov
+// gov : https://en.wikipedia.org/wiki/.gov
 gov
 
 // gp : http://www.nic.gp/index.php?lang=en
@@ -976,11 +970,11 @@ edu.gp
 org.gp
 asso.gp
 
-// gq : http://en.wikipedia.org/wiki/.gq
+// gq : https://en.wikipedia.org/wiki/.gq
 gq
 
 // gr : https://grweb.ics.forth.gr/english/1617-B-2005.html
-// Submitted by registry <segred@ics.forth.gr> 2008-06-09
+// Submitted by registry <segred@ics.forth.gr>
 gr
 com.gr
 edu.gr
@@ -988,7 +982,7 @@ net.gr
 org.gr
 gov.gr
 
-// gs : http://en.wikipedia.org/wiki/.gs
+// gs : https://en.wikipedia.org/wiki/.gs
 gs
 
 // gt : http://www.gt/politicas_de_registro.html
@@ -1004,18 +998,21 @@ org.gt
 // gu : http://gadao.gov.gu/registration.txt
 *.gu
 
-// gw : http://en.wikipedia.org/wiki/.gw
+// gw : https://en.wikipedia.org/wiki/.gw
 gw
 
-// gy : http://en.wikipedia.org/wiki/.gy
+// gy : https://en.wikipedia.org/wiki/.gy
 // http://registry.gy/
 gy
 co.gy
 com.gy
+edu.gy
+gov.gy
 net.gy
+org.gy
 
 // hk : https://www.hkdnr.hk
-// Submitted by registry <hk.tech@hkirc.hk> 2008-06-11
+// Submitted by registry <hk.tech@hkirc.hk>
 hk
 com.hk
 edu.hk
@@ -1039,7 +1036,7 @@ org.hk
 組織.hk
 組织.hk
 
-// hm : http://en.wikipedia.org/wiki/.hm
+// hm : https://en.wikipedia.org/wiki/.hm
 hm
 
 // hn : http://www.nic.hn/politicas/ps02,,05.html
@@ -1127,15 +1124,23 @@ or.id
 sch.id
 web.id
 
-// ie : http://en.wikipedia.org/wiki/.ie
+// ie : https://en.wikipedia.org/wiki/.ie
 ie
 gov.ie
 
-// il : http://en.wikipedia.org/wiki/.il
-*.il
+// il : http://www.isoc.org.il/domains/
+il
+ac.il
+co.il
+gov.il
+idf.il
+k12.il
+muni.il
+net.il
+org.il
 
 // im : https://www.nic.im/
-// Submitted by registry <info@nic.im> 2013-11-15
+// Submitted by registry <info@nic.im>
 im
 ac.im
 co.im
@@ -1147,9 +1152,9 @@ plc.co.im
 tt.im
 tv.im
 
-// in : http://en.wikipedia.org/wiki/.in
+// in : https://en.wikipedia.org/wiki/.in
 // see also: https://registry.in/Policies
-// Please note, that nic.in is not an offical eTLD, but used by most
+// Please note, that nic.in is not an official eTLD, but used by most
 // government institutions.
 in
 co.in
@@ -1165,10 +1170,10 @@ res.in
 gov.in
 mil.in
 
-// info : http://en.wikipedia.org/wiki/.info
+// info : https://en.wikipedia.org/wiki/.info
 info
 
-// int : http://en.wikipedia.org/wiki/.int
+// int : https://en.wikipedia.org/wiki/.int
 // Confirmed by registry <iana-questions@icann.org> 2008-06-18
 int
 eu.int
@@ -1213,7 +1218,7 @@ gov.is
 org.is
 int.is
 
-// it : http://en.wikipedia.org/wiki/.it
+// it : https://en.wikipedia.org/wiki/.it
 it
 gov.it
 edu.it
@@ -1611,12 +1616,12 @@ gov.jo
 mil.jo
 name.jo
 
-// jobs : http://en.wikipedia.org/wiki/.jobs
+// jobs : https://en.wikipedia.org/wiki/.jobs
 jobs
 
-// jp : http://en.wikipedia.org/wiki/.jp
+// jp : https://en.wikipedia.org/wiki/.jp
 // http://jprs.co.jp/en/jpdomain.html
-// Submitted by registry <info@jprs.jp> 2014-10-30
+// Submitted by registry <info@jprs.jp>
 jp
 // jp organizational type names
 ac.jp
@@ -2543,11 +2548,8 @@ arao.kumamoto.jp
 aso.kumamoto.jp
 choyo.kumamoto.jp
 gyokuto.kumamoto.jp
-hitoyoshi.kumamoto.jp
 kamiamakusa.kumamoto.jp
-kashima.kumamoto.jp
 kikuchi.kumamoto.jp
-kosa.kumamoto.jp
 kumamoto.kumamoto.jp
 mashiki.kumamoto.jp
 mifune.kumamoto.jp
@@ -2632,7 +2634,6 @@ iwanuma.miyagi.jp
 kakuda.miyagi.jp
 kami.miyagi.jp
 kawasaki.miyagi.jp
-kesennuma.miyagi.jp
 marumori.miyagi.jp
 matsushima.miyagi.jp
 minamisanriku.miyagi.jp
@@ -3443,7 +3444,7 @@ gov.ki
 info.ki
 com.ki
 
-// km : http://en.wikipedia.org/wiki/.km
+// km : https://en.wikipedia.org/wiki/.km
 // http://www.domaine.km/documents/charte.doc
 km
 org.km
@@ -3456,7 +3457,7 @@ mil.km
 ass.km
 com.km
 // These are only mentioned as proposed suggestions at domaine.km, but
-// http://en.wikipedia.org/wiki/.km says they're available for registration:
+// https://en.wikipedia.org/wiki/.km says they're available for registration:
 coop.km
 asso.km
 presse.km
@@ -3466,7 +3467,7 @@ pharmaciens.km
 veterinaire.km
 gouv.km
 
-// kn : http://en.wikipedia.org/wiki/.kn
+// kn : https://en.wikipedia.org/wiki/.kn
 // http://www.dot.kn/domainRules.html
 kn
 net.kn
@@ -3483,7 +3484,7 @@ org.kp
 rep.kp
 tra.kp
 
-// kr : http://en.wikipedia.org/wiki/.kr
+// kr : https://en.wikipedia.org/wiki/.kr
 // see also: http://domain.nida.or.kr/eng/registration.jsp
 kr
 ac.kr
@@ -3517,7 +3518,7 @@ jeonnam.kr
 seoul.kr
 ulsan.kr
 
-// kw : http://en.wikipedia.org/wiki/.kw
+// kw : https://en.wikipedia.org/wiki/.kw
 *.kw
 
 // ky : http://www.icta.ky/da_ky_reg_dom.php
@@ -3529,7 +3530,7 @@ com.ky
 org.ky
 net.ky
 
-// kz : http://en.wikipedia.org/wiki/.kz
+// kz : https://en.wikipedia.org/wiki/.kz
 // see also: http://www.nic.kz/rules/index.jsp
 kz
 org.kz
@@ -3539,8 +3540,8 @@ gov.kz
 mil.kz
 com.kz
 
-// la : http://en.wikipedia.org/wiki/.la
-// Submitted by registry <gavin.brown@nic.la> 2008-06-10
+// la : https://en.wikipedia.org/wiki/.la
+// Submitted by registry <gavin.brown@nic.la>
 la
 int.la
 net.la
@@ -3551,8 +3552,8 @@ per.la
 com.la
 org.la
 
-// lb : http://en.wikipedia.org/wiki/.lb
-// Submitted by registry <randy@psg.com> 2008-06-17
+// lb : https://en.wikipedia.org/wiki/.lb
+// Submitted by registry <randy@psg.com>
 lb
 com.lb
 edu.lb
@@ -3560,7 +3561,7 @@ gov.lb
 net.lb
 org.lb
 
-// lc : http://en.wikipedia.org/wiki/.lc
+// lc : https://en.wikipedia.org/wiki/.lc
 // see also: http://www.nic.lc/rules.htm
 lc
 com.lc
@@ -3570,7 +3571,7 @@ org.lc
 edu.lc
 gov.lc
 
-// li : http://en.wikipedia.org/wiki/.li
+// li : https://en.wikipedia.org/wiki/.li
 li
 
 // lk : http://www.nic.lk/seclevpr.html
@@ -3592,7 +3593,7 @@ hotel.lk
 ac.lk
 
 // lr : http://psg.com/dns/lr/lr.txt
-// Submitted by registry <randy@psg.com> 2008-06-17
+// Submitted by registry <randy@psg.com>
 lr
 com.lr
 edu.lr
@@ -3600,12 +3601,12 @@ gov.lr
 org.lr
 net.lr
 
-// ls : http://en.wikipedia.org/wiki/.ls
+// ls : https://en.wikipedia.org/wiki/.ls
 ls
 co.ls
 org.ls
 
-// lt : http://en.wikipedia.org/wiki/.lt
+// lt : https://en.wikipedia.org/wiki/.lt
 lt
 // gov.lt : http://www.gov.lt/index_en.php
 gov.lt
@@ -3637,7 +3638,7 @@ med.ly
 org.ly
 id.ly
 
-// ma : http://en.wikipedia.org/wiki/.ma
+// ma : https://en.wikipedia.org/wiki/.ma
 // http://www.anrt.ma/fr/admin/download/upload/file_fr782.pdf
 ma
 co.ma
@@ -3652,10 +3653,10 @@ mc
 tm.mc
 asso.mc
 
-// md : http://en.wikipedia.org/wiki/.md
+// md : https://en.wikipedia.org/wiki/.md
 md
 
-// me : http://en.wikipedia.org/wiki/.me
+// me : https://en.wikipedia.org/wiki/.me
 me
 co.me
 net.me
@@ -3678,13 +3679,13 @@ mil.mg
 com.mg
 co.mg
 
-// mh : http://en.wikipedia.org/wiki/.mh
+// mh : https://en.wikipedia.org/wiki/.mh
 mh
 
-// mil : http://en.wikipedia.org/wiki/.mil
+// mil : https://en.wikipedia.org/wiki/.mil
 mil
 
-// mk : http://en.wikipedia.org/wiki/.mk
+// mk : https://en.wikipedia.org/wiki/.mk
 // see also: http://dns.marnet.net.mk/postapka.php
 mk
 com.mk
@@ -3696,7 +3697,7 @@ inf.mk
 name.mk
 
 // ml : http://www.gobin.info/domainname/ml-template.doc
-// see also: http://en.wikipedia.org/wiki/.ml
+// see also: https://en.wikipedia.org/wiki/.ml
 ml
 com.ml
 edu.ml
@@ -3706,10 +3707,10 @@ net.ml
 org.ml
 presse.ml
 
-// mm : http://en.wikipedia.org/wiki/.mm
+// mm : https://en.wikipedia.org/wiki/.mm
 *.mm
 
-// mn : http://en.wikipedia.org/wiki/.mn
+// mn : https://en.wikipedia.org/wiki/.mn
 mn
 gov.mn
 edu.mn
@@ -3723,17 +3724,17 @@ org.mo
 edu.mo
 gov.mo
 
-// mobi : http://en.wikipedia.org/wiki/.mobi
+// mobi : https://en.wikipedia.org/wiki/.mobi
 mobi
 
 // mp : http://www.dot.mp/
 // Confirmed by registry <dcamacho@saipan.com> 2008-06-17
 mp
 
-// mq : http://en.wikipedia.org/wiki/.mq
+// mq : https://en.wikipedia.org/wiki/.mq
 mq
 
-// mr : http://en.wikipedia.org/wiki/.mr
+// mr : https://en.wikipedia.org/wiki/.mr
 mr
 gov.mr
 
@@ -3746,14 +3747,14 @@ net.ms
 org.ms
 
 // mt : https://www.nic.org.mt/go/policy
-// Submitted by registry <help@nic.org.mt> 2013-11-19
+// Submitted by registry <help@nic.org.mt>
 mt
 com.mt
 edu.mt
 net.mt
 org.mt
 
-// mu : http://en.wikipedia.org/wiki/.mu
+// mu : https://en.wikipedia.org/wiki/.mu
 mu
 com.mu
 net.mu
@@ -4315,7 +4316,7 @@ zoology.museum
 ירושלים.museum
 иком.museum
 
-// mv : http://en.wikipedia.org/wiki/.mv
+// mv : https://en.wikipedia.org/wiki/.mv
 // "mv" included because, contra Wikipedia, google.mv exists.
 mv
 aero.mv
@@ -4348,7 +4349,7 @@ net.mw
 org.mw
 
 // mx : http://www.nic.mx/
-// Submitted by registry <farias@nic.mx> 2008-06-19
+// Submitted by registry <farias@nic.mx>
 mx
 com.mx
 org.mx
@@ -4366,9 +4367,17 @@ edu.my
 mil.my
 name.my
 
-// mz : http://www.gobin.info/domainname/mz-template.doc
-*.mz
-!teledata.mz
+// mz : http://www.uem.mz/
+// Submitted by registry <antonio@uem.mz>
+mz
+ac.mz
+adv.mz
+co.mz
+edu.mz
+gov.mz
+mil.mz
+net.mz
+org.mz
 
 // na : http://www.na-nic.com.na/
 // http://www.info.na/domain/
@@ -4398,13 +4407,13 @@ name
 nc
 asso.nc
 
-// ne : http://en.wikipedia.org/wiki/.ne
+// ne : https://en.wikipedia.org/wiki/.ne
 ne
 
-// net : http://en.wikipedia.org/wiki/.net
+// net : https://en.wikipedia.org/wiki/.net
 net
 
-// nf : http://en.wikipedia.org/wiki/.nf
+// nf : https://en.wikipedia.org/wiki/.nf
 nf
 com.nf
 net.nf
@@ -4417,22 +4426,37 @@ info.nf
 other.nf
 store.nf
 
-// ng : http://psg.com/dns/ng/
+// ng : http://www.nira.org.ng/index.php/join-us/register-ng-domain/189-nira-slds
 ng
 com.ng
 edu.ng
+gov.ng
+i.ng
+mil.ng
+mobi.ng
 name.ng
 net.ng
 org.ng
 sch.ng
-gov.ng
-mil.ng
-mobi.ng
 
-// ni : http://www.nic.ni/dominios.htm
-*.ni
+// ni : http://www.nic.ni/
+ni
+ac.ni
+biz.ni
+co.ni
+com.ni
+edu.ni
+gob.ni
+in.ni
+info.ni
+int.ni
+mil.ni
+net.ni
+nom.ni
+org.ni
+web.ni
 
-// nl : http://en.wikipedia.org/wiki/.nl
+// nl : https://en.wikipedia.org/wiki/.nl
 //      https://www.sidn.nl/
 //      ccTLD for the Netherlands
 nl
@@ -5211,7 +5235,7 @@ våler.hedmark.no
 *.np
 
 // nr : http://cenpac.net.nr/dns/index.html
-// Confirmed by registry <technician@cenpac.net.nr> 2008-06-17
+// Submitted by registry <technician@cenpac.net.nr>
 nr
 biz.nr
 info.nr
@@ -5221,11 +5245,11 @@ org.nr
 net.nr
 com.nr
 
-// nu : http://en.wikipedia.org/wiki/.nu
+// nu : https://en.wikipedia.org/wiki/.nu
 nu
 
-// nz : http://en.wikipedia.org/wiki/.nz
-// Confirmed by registry <jay@nzrs.net.nz> 2014-05-19
+// nz : https://en.wikipedia.org/wiki/.nz
+// Submitted by registry <jay@nzrs.net.nz>
 nz
 ac.nz
 co.nz
@@ -5244,7 +5268,7 @@ org.nz
 parliament.nz
 school.nz
 
-// om : http://en.wikipedia.org/wiki/.om
+// om : https://en.wikipedia.org/wiki/.om
 om
 co.om
 com.om
@@ -5256,7 +5280,10 @@ net.om
 org.om
 pro.om
 
-// org : http://en.wikipedia.org/wiki/.org
+// onion : https://tools.ietf.org/html/rfc7686
+onion
+
+// org : https://en.wikipedia.org/wiki/.org
 org
 
 // pa : http://www.nic.pa/
@@ -5291,11 +5318,11 @@ com.pf
 org.pf
 edu.pf
 
-// pg : http://en.wikipedia.org/wiki/.pg
+// pg : https://en.wikipedia.org/wiki/.pg
 *.pg
 
 // ph : http://www.domains.ph/FAQ2.asp
-// Submitted by registry <jed@email.com.ph> 2008-06-13
+// Submitted by registry <jed@email.com.ph>
 ph
 com.ph
 net.ph
@@ -5324,7 +5351,7 @@ gos.pk
 info.pk
 
 // pl http://www.dns.pl/english/index.html
-// updated by .PL registry on 2015-04-28
+// Submitted by registry
 pl
 com.pl
 net.pl
@@ -5541,7 +5568,7 @@ org.pn
 edu.pn
 net.pn
 
-// post : http://en.wikipedia.org/wiki/.post
+// post : https://en.wikipedia.org/wiki/.post
 post
 
 // pr : http://www.nic.pr/index.asp?f=1
@@ -5556,22 +5583,26 @@ pro.pr
 biz.pr
 info.pr
 name.pr
-// these aren't mentioned on nic.pr, but on http://en.wikipedia.org/wiki/.pr
+// these aren't mentioned on nic.pr, but on https://en.wikipedia.org/wiki/.pr
 est.pr
 prof.pr
 ac.pr
 
-// pro : http://www.nic.pro/support_faq.htm
+// pro : http://registry.pro/get-pro
 pro
+aaa.pro
 aca.pro
+acct.pro
+avocat.pro
 bar.pro
 cpa.pro
+eng.pro
 jur.pro
 law.pro
 med.pro
-eng.pro
+recht.pro
 
-// ps : http://en.wikipedia.org/wiki/.ps
+// ps : https://en.wikipedia.org/wiki/.ps
 // http://www.nic.ps/registration/policy.html#reg
 ps
 edu.ps
@@ -5593,7 +5624,7 @@ publ.pt
 com.pt
 nome.pt
 
-// pw : http://en.wikipedia.org/wiki/.pw
+// pw : https://en.wikipedia.org/wiki/.pw
 pw
 co.pw
 ne.pw
@@ -5603,7 +5634,7 @@ go.pw
 belau.pw
 
 // py : http://www.nic.py/pautas.html#seccion_9
-// Confirmed by registry 2012-10-03
+// Submitted by registry
 py
 com.py
 coop.py
@@ -5626,171 +5657,40 @@ sch.qa
 
 // re : http://www.afnic.re/obtenir/chartes/nommage-re/annexe-descriptifs
 re
-com.re
 asso.re
+com.re
 nom.re
 
 // ro : http://www.rotld.ro/
 ro
-com.ro
-org.ro
-tm.ro
-nt.ro
-nom.ro
-info.ro
-rec.ro
 arts.ro
+com.ro
 firm.ro
+info.ro
+nom.ro
+nt.ro
+org.ro
+rec.ro
 store.ro
+tm.ro
 www.ro
 
-// rs : http://en.wikipedia.org/wiki/.rs
+// rs : https://www.rnids.rs/en/domains/national-domains
 rs
-co.rs
-org.rs
-edu.rs
 ac.rs
+co.rs
+edu.rs
 gov.rs
 in.rs
+org.rs
 
-// ru : http://www.cctld.ru/ru/docs/aktiv_8.php
-// Industry domains
+// ru : https://cctld.ru/en/domains/domens_ru/reserved/
 ru
 ac.ru
-com.ru
 edu.ru
-int.ru
-net.ru
-org.ru
-pp.ru
-// Geographical domains
-adygeya.ru
-altai.ru
-amur.ru
-arkhangelsk.ru
-astrakhan.ru
-bashkiria.ru
-belgorod.ru
-bir.ru
-bryansk.ru
-buryatia.ru
-cbg.ru
-chel.ru
-chelyabinsk.ru
-chita.ru
-chukotka.ru
-chuvashia.ru
-dagestan.ru
-dudinka.ru
-e-burg.ru
-grozny.ru
-irkutsk.ru
-ivanovo.ru
-izhevsk.ru
-jar.ru
-joshkar-ola.ru
-kalmykia.ru
-kaluga.ru
-kamchatka.ru
-karelia.ru
-kazan.ru
-kchr.ru
-kemerovo.ru
-khabarovsk.ru
-khakassia.ru
-khv.ru
-kirov.ru
-koenig.ru
-komi.ru
-kostroma.ru
-krasnoyarsk.ru
-kuban.ru
-kurgan.ru
-kursk.ru
-lipetsk.ru
-magadan.ru
-mari.ru
-mari-el.ru
-marine.ru
-mordovia.ru
-// mosreg.ru  Bug 1090800 - removed at request of Aleksey Konstantinov <konstantinovav@mosreg.ru>
-msk.ru
-murmansk.ru
-nalchik.ru
-nnov.ru
-nov.ru
-novosibirsk.ru
-nsk.ru
-omsk.ru
-orenburg.ru
-oryol.ru
-palana.ru
-penza.ru
-perm.ru
-ptz.ru
-rnd.ru
-ryazan.ru
-sakhalin.ru
-samara.ru
-saratov.ru
-simbirsk.ru
-smolensk.ru
-spb.ru
-stavropol.ru
-stv.ru
-surgut.ru
-tambov.ru
-tatarstan.ru
-tom.ru
-tomsk.ru
-tsaritsyn.ru
-tsk.ru
-tula.ru
-tuva.ru
-tver.ru
-tyumen.ru
-udm.ru
-udmurtia.ru
-ulan-ude.ru
-vladikavkaz.ru
-vladimir.ru
-vladivostok.ru
-volgograd.ru
-vologda.ru
-voronezh.ru
-vrn.ru
-vyatka.ru
-yakutia.ru
-yamal.ru
-yaroslavl.ru
-yekaterinburg.ru
-yuzhno-sakhalinsk.ru
-// More geographical domains
-amursk.ru
-baikal.ru
-cmw.ru
-fareast.ru
-jamal.ru
-kms.ru
-k-uralsk.ru
-kustanai.ru
-kuzbass.ru
-magnitka.ru
-mytis.ru
-nakhodka.ru
-nkz.ru
-norilsk.ru
-oskol.ru
-pyatigorsk.ru
-rubtsovsk.ru
-snz.ru
-syzran.ru
-vdonsk.ru
-zgrad.ru
-// State domains
 gov.ru
+int.ru
 mil.ru
-// Technical domains
 test.ru
 
 // rw : http://www.nic.rw/cgi-bin/policy.pl
@@ -5817,7 +5717,7 @@ edu.sa
 sch.sa
 
 // sb : http://www.sbnic.net.sb/
-// Submitted by registry <lee.humphries@telekom.com.sb> 2008-06-08
+// Submitted by registry <lee.humphries@telekom.com.sb>
 sb
 com.sb
 edu.sb
@@ -5834,7 +5734,7 @@ org.sc
 edu.sc
 
 // sd : http://www.isoc.sd/sudanic.isoc.sd/billing_pricing.htm
-// Submitted by registry <admin@isoc.sd> 2008-06-17
+// Submitted by registry <admin@isoc.sd>
 sd
 com.sd
 net.sd
@@ -5845,8 +5745,8 @@ tv.sd
 gov.sd
 info.sd
 
-// se : http://en.wikipedia.org/wiki/.se
-// Submitted by registry <patrik.wallstrom@iis.se> 2014-03-18
+// se : https://en.wikipedia.org/wiki/.se
+// Submitted by registry <patrik.wallstrom@iis.se>
 se
 a.se
 ac.se
@@ -5905,19 +5805,19 @@ gov.sh
 org.sh
 mil.sh
 
-// si : http://en.wikipedia.org/wiki/.si
+// si : https://en.wikipedia.org/wiki/.si
 si
 
 // sj : No registrations at this time.
-// Submitted by registry <jarle@uninett.no> 2008-06-16
+// Submitted by registry <jarle@uninett.no>
 sj
 
-// sk : http://en.wikipedia.org/wiki/.sk
+// sk : https://en.wikipedia.org/wiki/.sk
 // list of 2nd level domains ?
 sk
 
 // sl : http://www.nic.sl
-// Submitted by registry <adam@neoip.com> 2008-06-12
+// Submitted by registry <adam@neoip.com>
 sl
 com.sl
 net.sl
@@ -5925,10 +5825,10 @@ edu.sl
 gov.sl
 org.sl
 
-// sm : http://en.wikipedia.org/wiki/.sm
+// sm : https://en.wikipedia.org/wiki/.sm
 sm
 
-// sn : http://en.wikipedia.org/wiki/.sn
+// sn : https://en.wikipedia.org/wiki/.sn
 sn
 art.sn
 com.sn
@@ -5944,7 +5844,7 @@ com.so
 net.so
 org.so
 
-// sr : http://en.wikipedia.org/wiki/.sr
+// sr : https://en.wikipedia.org/wiki/.sr
 sr
 
 // st : http://www.nic.st/html/policyrules/
@@ -5962,40 +5862,8 @@ principe.st
 saotome.st
 store.st
 
-// su : http://en.wikipedia.org/wiki/.su
+// su : https://en.wikipedia.org/wiki/.su
 su
-adygeya.su
-arkhangelsk.su
-balashov.su
-bashkiria.su
-bryansk.su
-dagestan.su
-grozny.su
-ivanovo.su
-kalmykia.su
-kaluga.su
-karelia.su
-khakassia.su
-krasnodar.su
-kurgan.su
-lenug.su
-mordovia.su
-msk.su
-murmansk.su
-nalchik.su
-nov.su
-obninsk.su
-penza.su
-pokrovsk.su
-sochi.su
-spb.su
-togliatti.su
-troitsk.su
-tula.su
-tuva.su
-vladikavkaz.su
-vladimir.su
-vologda.su
 
 // sv : http://www.svnet.org.sv/niveldos.pdf
 sv
@@ -6005,12 +5873,12 @@ gob.sv
 org.sv
 red.sv
 
-// sx : http://en.wikipedia.org/wiki/.sx
-// Confirmed by registry <jcvignes@openregistry.com> 2012-05-31
+// sx : https://en.wikipedia.org/wiki/.sx
+// Submitted by registry <jcvignes@openregistry.com>
 sx
 gov.sx
 
-// sy : http://en.wikipedia.org/wiki/.sy
+// sy : https://en.wikipedia.org/wiki/.sy
 // see also: http://www.gobin.info/domainname/sy.doc
 sy
 edu.sy
@@ -6020,32 +5888,32 @@ mil.sy
 com.sy
 org.sy
 
-// sz : http://en.wikipedia.org/wiki/.sz
+// sz : https://en.wikipedia.org/wiki/.sz
 // http://www.sispa.org.sz/
 sz
 co.sz
 ac.sz
 org.sz
 
-// tc : http://en.wikipedia.org/wiki/.tc
+// tc : https://en.wikipedia.org/wiki/.tc
 tc
 
-// td : http://en.wikipedia.org/wiki/.td
+// td : https://en.wikipedia.org/wiki/.td
 td
 
-// tel: http://en.wikipedia.org/wiki/.tel
+// tel: https://en.wikipedia.org/wiki/.tel
 // http://www.telnic.org/
 tel
 
-// tf : http://en.wikipedia.org/wiki/.tf
+// tf : https://en.wikipedia.org/wiki/.tf
 tf
 
-// tg : http://en.wikipedia.org/wiki/.tg
+// tg : https://en.wikipedia.org/wiki/.tg
 // http://www.nic.tg/
 tg
 
-// th : http://en.wikipedia.org/wiki/.th
-// Submitted by registry <krit@thains.co.th> 2008-06-17
+// th : https://en.wikipedia.org/wiki/.th
+// Submitted by registry <krit@thains.co.th>
 th
 ac.th
 co.th
@@ -6073,10 +5941,10 @@ org.tj
 test.tj
 web.tj
 
-// tk : http://en.wikipedia.org/wiki/.tk
+// tk : https://en.wikipedia.org/wiki/.tk
 tk
 
-// tl : http://en.wikipedia.org/wiki/.tl
+// tl : https://en.wikipedia.org/wiki/.tl
 tl
 gov.tl
 
@@ -6091,7 +5959,7 @@ gov.tm
 mil.tm
 edu.tm
 
-// tn : http://en.wikipedia.org/wiki/.tn
+// tn : https://en.wikipedia.org/wiki/.tn
 // http://whois.ati.tn/
 tn
 com.tn
@@ -6115,8 +5983,8 @@ agrinet.tn
 defense.tn
 turen.tn
 
-// to : http://en.wikipedia.org/wiki/.to
-// Submitted by registry <egullich@colo.to> 2008-06-17
+// to : https://en.wikipedia.org/wiki/.to
+// Submitted by registry <egullich@colo.to>
 to
 com.to
 gov.to
@@ -6125,13 +5993,9 @@ org.to
 edu.to
 mil.to
 
-// tp : No registrations at this time.
-// Submitted by Ryan Sleevi <ryan.sleevi@gmail.com> 2014-01-03
-tp
-
 // subTLDs: https://www.nic.tr/forms/eng/policies.pdf
 //     and: https://www.nic.tr/forms/politikalar.pdf
-// Submitted by <mehmetgurevin@gmail.com> 2014-07-19
+// Submitted by <mehmetgurevin@gmail.com>
 tr
 com.tr
 info.tr
@@ -6160,7 +6024,7 @@ nc.tr
 // Used by government agencies of Northern Cyprus
 gov.nc.tr
 
-// travel : http://en.wikipedia.org/wiki/.travel
+// travel : https://en.wikipedia.org/wiki/.travel
 travel
 
 // tt : http://www.nic.tt/
@@ -6183,12 +6047,12 @@ name.tt
 gov.tt
 edu.tt
 
-// tv : http://en.wikipedia.org/wiki/.tv
+// tv : https://en.wikipedia.org/wiki/.tv
 // Not listing any 2LDs as reserved since none seem to exist in practice,
 // Wikipedia notwithstanding.
 tv
 
-// tw : http://en.wikipedia.org/wiki/.tw
+// tw : https://en.wikipedia.org/wiki/.tw
 tw
 edu.tw
 gov.tw
@@ -6205,7 +6069,7 @@ club.tw
 商業.tw
 
 // tz : http://www.tznic.or.tz/index.php/domains
-// Confirmed by registry <manager@tznic.or.tz> 2013-01-22
+// Submitted by registry <manager@tznic.or.tz>
 tz
 ac.tz
 co.tz
@@ -6221,7 +6085,7 @@ sc.tz
 tv.tz
 
 // ua : https://hostmaster.ua/policy/?ua
-// Submitted by registry <dk@cctld.ua> 2012-04-27
+// Submitted by registry <dk@cctld.ua>
 ua
 // ua 2LD
 com.ua
@@ -6314,7 +6178,7 @@ ne.ug
 com.ug
 org.ug
 
-// uk : http://en.wikipedia.org/wiki/.uk
+// uk : https://en.wikipedia.org/wiki/.uk
 // Submitted by registry <Michael.Daly@nominet.org.uk>
 uk
 ac.uk
@@ -6329,7 +6193,7 @@ plc.uk
 police.uk
 *.sch.uk
 
-// us : http://en.wikipedia.org/wiki/.us
+// us : https://en.wikipedia.org/wiki/.us
 us
 dni.us
 fed.us
@@ -6517,7 +6381,7 @@ lib.ca.us
 lib.co.us
 lib.ct.us
 lib.dc.us
-lib.de.us
+// lib.de.us  Issue #243 - Moved to Private section at request of Ed Moore <Ed.Moore@lib.de.us>
 lib.fl.us
 lib.ga.us
 lib.gu.us
@@ -6564,8 +6428,8 @@ lib.wi.us
 // lib.wv.us  Bug 941670 - Removed at request of Larry W Arnold <arnold@wvlc.lib.wv.us>
 lib.wy.us
 // k12.ma.us contains school districts in Massachusetts. The 4LDs are
-//  managed indepedently except for private (PVT), charter (CHTR) and
-//  parochial (PAROCH) schools.  Those are delegated dorectly to the
+//  managed independently except for private (PVT), charter (CHTR) and
+//  parochial (PAROCH) schools.  Those are delegated directly to the
 //  5LD operators.   <k12-ma-hostmaster _ at _ rsuc.gweep.net>
 pvt.k12.ma.us
 chtr.k12.ma.us
@@ -6587,11 +6451,11 @@ com.uz
 net.uz
 org.uz
 
-// va : http://en.wikipedia.org/wiki/.va
+// va : https://en.wikipedia.org/wiki/.va
 va
 
-// vc : http://en.wikipedia.org/wiki/.vc
-// Submitted by registry <kshah@ca.afilias.info> 2008-06-13
+// vc : https://en.wikipedia.org/wiki/.vc
+// Submitted by registry <kshah@ca.afilias.info>
 vc
 com.vc
 net.vc
@@ -6601,8 +6465,7 @@ mil.vc
 edu.vc
 
 // ve : https://registro.nic.ve/
-// Confirmed by registry 2012-10-04
-// Updated 2014-05-20 - Bug 940478
+// Submitted by registry
 ve
 arts.ve
 co.ve
@@ -6622,7 +6485,7 @@ store.ve
 tec.ve
 web.ve
 
-// vg : http://en.wikipedia.org/wiki/.vg
+// vg : https://en.wikipedia.org/wiki/.vg
 vg
 
 // vi : http://www.nic.vi/newdomainform.htm
@@ -6651,7 +6514,7 @@ name.vn
 pro.vn
 health.vn
 
-// vu : http://en.wikipedia.org/wiki/.vu
+// vu : https://en.wikipedia.org/wiki/.vu
 // http://www.vunic.vu/
 vu
 com.vu
@@ -6662,7 +6525,7 @@ org.vu
 // wf : http://www.afnic.fr/medias/documents/AFNIC-naming-policy2012.pdf
 wf
 
-// ws : http://en.wikipedia.org/wiki/.ws
+// ws : https://en.wikipedia.org/wiki/.ws
 // http://samoanic.ws/index.dhtml
 ws
 com.ws
@@ -6712,6 +6575,9 @@ yt
 // xn--wgbh1c ("Egypt/Masr", Arabic) : EG
 // http://www.dotmasr.eg/
 مصر
+
+// xn--e1a4c ("eu", Cyrillic) : EU
+ею
 
 // xn--node ("ge", Georgian Mkhedruli) : GE
 გე
@@ -6816,7 +6682,7 @@ yt
 فلسطين
 
 // xn--90a3ac ("srb", Cyrillic) : RS
-// http://www.rnids.rs/en/the-.срб-domain
+// https://www.rnids.rs/en/domains/national-domains
 срб
 пр.срб
 орг.срб
@@ -6895,7 +6761,7 @@ xxx
 
 // za : http://www.zadna.org.za/content/page/domain-information
 ac.za
-agrica.za
+agric.za
 alt.za
 co.za
 edu.za
@@ -6912,14 +6778,26 @@ school.za
 tm.za
 web.za
 
-// zm : http://en.wikipedia.org/wiki/.zm
-*.zm
+// zm : https://zicta.zm/
+// Submitted by registry <info@zicta.zm>
+zm
+ac.zm
+biz.zm
+co.zm
+com.zm
+edu.zm
+gov.zm
+info.zm
+mil.zm
+net.zm
+org.zm
+sch.zm
 
-// zw : http://en.wikipedia.org/wiki/.zw
+// zw : https://en.wikipedia.org/wiki/.zw
 *.zw
 
 
-// List of new gTLDs imported from https://newgtlds.icann.org/newgtlds.csv on 2015-08-26T23:57:22Z
+// List of new gTLDs imported from https://newgtlds.icann.org/newgtlds.csv on 2016-11-29T01:06:51Z
 
 // aaa : 2015-02-26 American Automobile Association, Inc.
 aaa
@@ -6995,9 +6873,6 @@ afl
 
 // africa : 2014-03-24 ZA Central Registry NPC trading as Registry.Africa
 africa
-
-// africamagic : 2015-03-05 Electronic Media Network (Pty) Ltd
-africamagic
 
 // agakhan : 2015-04-23 Fondation Aga Khan (Aga Khan Foundation)
 agakhan
@@ -7077,6 +6952,9 @@ anquan
 // anz : 2015-07-31 Australia and New Zealand Banking Group Limited
 anz
 
+// aol : 2015-09-17 AOL Inc.
+aol
+
 // apartments : 2014-12-11 June Maple, LLC
 apartments
 
@@ -7089,6 +6967,9 @@ apple
 // aquarelle : 2014-07-24 Aquarelle.com
 aquarelle
 
+// arab : 2015-11-12 League of Arab States
+arab
+
 // aramco : 2014-11-20 Aramco Services Company
 aramco
 
@@ -7097,6 +6978,9 @@ archi
 
 // army : 2014-03-06 United TLD Holdco Ltd.
 army
+
+// art : 2016-03-24 UK Creative Ideas Limited
+art
 
 // arte : 2014-12-11 Association Relative à la Télévision Européenne G.E.I.E.
 arte
@@ -7185,6 +7069,9 @@ barefoot
 // bargains : 2013-11-14 Half Hallow, LLC
 bargains
 
+// baseball : 2015-10-29 MLB Advanced Media DH, LLC
+baseball
+
 // basketball : 2015-08-20 Fédération Internationale de Basketball (FIBA)
 basketball
 
@@ -7211,6 +7098,9 @@ bcn
 
 // beats : 2015-05-14 Beats Electronics, LLC
 beats
+
+// beauty : 2015-12-03 L'Oréal
+beauty
 
 // beer : 2014-01-09 Top Level Domain Holdings Limited
 beer
@@ -7263,7 +7153,7 @@ blanco
 // blockbuster : 2015-07-30 Dish DBS Corporation
 blockbuster
 
-// blog : 2015-05-14 PRIMER NIVEL S.A.
+// blog : 2015-05-14
 blog
 
 // bloomberg : 2014-07-17 Bloomberg IP Holdings LLC
@@ -7302,6 +7192,9 @@ bond
 // boo : 2014-01-30 Charleston Road Registry Inc.
 boo
 
+// book : 2015-08-27 Amazon EU S.à r.l.
+book
+
 // booking : 2015-07-16 Booking.com B.V.
 booking
 
@@ -7314,11 +7207,17 @@ bosch
 // bostik : 2015-05-28 Bostik SA
 bostik
 
+// boston : 2015-12-10
+boston
+
 // bot : 2014-12-18 Amazon EU S.à r.l.
 bot
 
 // boutique : 2013-11-14 Over Galley, LLC
 boutique
+
+// box : 2015-11-12 NS1 Limited
+box
 
 // bradesco : 2014-12-18 Banco Bradesco S.A.
 bradesco
@@ -7377,6 +7276,9 @@ call
 // calvinklein : 2015-07-30 PVH gTLD Holdings LLC
 calvinklein
 
+// cam : 2016-04-21 AC Webconnecting Holding B.V.
+cam
+
 // camera : 2013-08-27 Atomic Maple, LLC
 camera
 
@@ -7425,6 +7327,12 @@ cartier
 // casa : 2013-11-21 Top Level Domain Holdings Limited
 casa
 
+// case : 2015-09-03 CNH Industrial N.V.
+case
+
+// caseih : 2015-09-03 CNH Industrial N.V.
+caseih
+
 // cash : 2014-03-06 Delta Lake, LLC
 cash
 
@@ -7433,6 +7341,9 @@ casino
 
 // catering : 2013-12-05 New Falls. LLC
 catering
+
+// catholic : 2015-10-21 Pontificium Consilium de Comunicationibus Socialibus (PCCS) (Pontifical Council for Social Communication)
+catholic
 
 // cba : 2014-06-26 COMMONWEALTH BANK OF AUSTRALIA
 cba
@@ -7533,6 +7444,9 @@ click
 // clinic : 2014-03-20 Goose Park, LLC
 clinic
 
+// clinique : 2015-10-01 The Estée Lauder Companies Inc.
+clinique
+
 // clothing : 2013-08-27 Steel Lake, LLC
 clothing
 
@@ -7571,6 +7485,9 @@ community
 
 // company : 2013-11-07 Silver Avenue, LLC
 company
+
+// compare : 2015-10-08 iSelect Ltd
+compare
 
 // computer : 2013-10-24 Pine Mill, LLC
 computer
@@ -7635,6 +7552,9 @@ crown
 // crs : 2014-04-03 Federated Co-operatives Limited
 crs
 
+// cruise : 2015-12-10 Viking River Cruises (Bermuda) Ltd.
+cruise
+
 // cruises : 2013-12-05 Spring Way, LLC
 cruises
 
@@ -7658,6 +7578,9 @@ dad
 
 // dance : 2013-10-24 United TLD Holdco Ltd.
 dance
+
+// data : 2016-06-02 Dish DBS Corporation
+data
 
 // date : 2014-11-20 dot Date Limited
 date
@@ -7746,11 +7669,17 @@ discover
 // dish : 2015-07-30 Dish DBS Corporation
 dish
 
+// diy : 2015-11-05 Lifestyle Domain Holdings, Inc.
+diy
+
 // dnp : 2013-12-13 Dai Nippon Printing Co., Ltd.
 dnp
 
 // docs : 2014-10-16 Charleston Road Registry Inc.
 docs
+
+// doctor : 2016-06-02 Brice Trail, LLC
+doctor
 
 // dodge : 2015-07-30 FCA US LLC.
 dodge
@@ -7764,9 +7693,6 @@ doha
 // domains : 2013-10-17 Sugar Cross, LLC
 domains
 
-// doosan : 2014-04-03 Doosan Corporation
-doosan
-
 // dot : 2015-05-21 Dish DBS Corporation
 dot
 
@@ -7775,9 +7701,6 @@ download
 
 // drive : 2015-03-05 Charleston Road Registry Inc.
 drive
-
-// dstv : 2015-03-12 MultiChoice (Proprietary) Limited
-dstv
 
 // dtv : 2015-06-04 Dish DBS Corporation
 dtv
@@ -7794,7 +7717,7 @@ dunlop
 // duns : 2015-08-06 The Dun & Bradstreet Corporation
 duns
 
-// dupont : 2015-06-25 E.I. du Pont de Nemours and Company
+// dupont : 2015-06-25 E. I. du Pont de Nemours and Company
 dupont
 
 // durban : 2014-03-24 ZA Central Registry NPC trading as ZA Central Registry
@@ -7802,6 +7725,9 @@ durban
 
 // dvag : 2014-06-23 Deutsche Vermögensberatung Aktiengesellschaft DVAG
 dvag
+
+// dvr : 2016-05-26 Hughes Satellite Systems Corporation
+dvr
 
 // dwg : 2015-07-23 Autodesk, Inc.
 dwg
@@ -7811,6 +7737,9 @@ earth
 
 // eat : 2014-01-23 Charleston Road Registry Inc.
 eat
+
+// eco : 2016-07-08 Big Room Inc.
+eco
 
 // edeka : 2014-12-18 EDEKA Verband kaufmännischer Genossenschaften e.V.
 edeka
@@ -7823,9 +7752,6 @@ email
 
 // emerck : 2014-04-03 Merck KGaA
 emerck
-
-// emerson : 2015-07-23 Emerson Electric Co.
-emerson
 
 // energy : 2014-09-11 Binky Birch, LLC
 energy
@@ -7862,6 +7788,9 @@ estate
 
 // esurance : 2015-07-23 Esurance Insurance Company
 esurance
+
+// etisalat : 2015-09-03 Emirates Telecommunications Corporation (trading as Etisalat)
+etisalat
 
 // eurovision : 2014-04-24 European Broadcasting Union (EBU)
 eurovision
@@ -7992,14 +7921,14 @@ florist
 // flowers : 2014-10-09 Uniregistry, Corp.
 flowers
 
-// flsmidth : 2014-07-24 FLSmidth A/S
-flsmidth
-
 // fly : 2014-05-08 Charleston Road Registry Inc.
 fly
 
 // foo : 2014-01-23 Charleston Road Registry Inc.
 foo
+
+// food : 2016-04-21 Lifestyle Domain Holdings, Inc.
+food
 
 // foodnetwork : 2015-07-02 Lifestyle Domain Holdings, Inc.
 foodnetwork
@@ -8021,6 +7950,12 @@ forum
 
 // foundation : 2013-12-05 John Dale, LLC
 foundation
+
+// fox : 2015-09-11 FOX Registry, LLC
+fox
+
+// free : 2015-12-10 Amazon EU S.à r.l.
+free
 
 // fresenius : 2015-07-30 Fresenius Immobilien-Verwaltungs-GmbH
 fresenius
@@ -8045,6 +7980,9 @@ fujitsu
 
 // fujixerox : 2015-07-23 Xerox DNHC LLC
 fujixerox
+
+// fun : 2016-01-14
+fun
 
 // fund : 2014-03-20 John Castle, LLC
 fund
@@ -8073,7 +8011,7 @@ gallup
 // game : 2015-05-28 Uniregistry, Corp.
 game
 
-// games : 2015-05-28 Foggy Beach, LLC
+// games : 2015-05-28
 games
 
 // gap : 2015-07-31 The Gap, Inc.
@@ -8133,6 +8071,9 @@ globo
 // gmail : 2014-05-01 Charleston Road Registry Inc.
 gmail
 
+// gmbh : 2016-01-29 Extra Dynamite, LLC
+gmbh
+
 // gmo : 2014-01-09 GMO Internet, Inc.
 gmo
 
@@ -8172,9 +8113,6 @@ gop
 // got : 2014-12-18 Amazon EU S.à r.l.
 got
 
-// gotv : 2015-03-12 MultiChoice (Proprietary) Limited
-gotv
-
 // grainger : 2015-05-07 Grainger Registry Services, LLC
 grainger
 
@@ -8189,6 +8127,9 @@ green
 
 // gripe : 2014-03-06 Corn Sunset, LLC
 gripe
+
+// grocery : 2016-06-16 Wal-Mart Stores, Inc.
+grocery
 
 // group : 2014-08-15 Romeo Town, LLC
 group
@@ -8210,6 +8151,9 @@ guitars
 
 // guru : 2013-08-27 Pioneer Cypress, LLC
 guru
+
+// hair : 2015-12-03 L'Oréal
+hair
 
 // hamburg : 2014-02-20 Hamburg Top-Level-Domain GmbH
 hamburg
@@ -8259,7 +8203,7 @@ hisamitsu
 // hitachi : 2014-10-31 Hitachi, Ltd.
 hitachi
 
-// hiv : 2014-03-13 dotHIV gemeinnuetziger e.V.
+// hiv : 2014-03-13
 hiv
 
 // hkt : 2015-05-14 PCCW-HKT DataCom Services Limited
@@ -8295,14 +8239,23 @@ honeywell
 // horse : 2013-11-21 Top Level Domain Holdings Limited
 horse
 
+// hospital : 2016-10-20 Ruby Pike, LLC
+hospital
+
 // host : 2014-04-17 DotHost Inc.
 host
 
 // hosting : 2014-05-29 Uniregistry, Corp.
 hosting
 
+// hot : 2015-08-27 Amazon EU S.à r.l.
+hot
+
 // hoteles : 2015-03-05 Travel Reservations SRL
 hoteles
+
+// hotels : 2016-04-07 Booking.com B.V.
+hotels
 
 // hotmail : 2014-12-18 Microsoft Corporation
 hotmail
@@ -8421,6 +8374,9 @@ itau
 // itv : 2015-07-09 ITV Services Limited
 itv
 
+// iveco : 2015-09-03 CNH Industrial N.V.
+iveco
+
 // iwc : 2014-06-23 Richemont DNS Inc.
 iwc
 
@@ -8439,7 +8395,7 @@ jcp
 // jeep : 2015-07-30 FCA US LLC.
 jeep
 
-// jetzt : 2014-01-09 New TLD Company AB
+// jetzt : 2014-01-09
 jetzt
 
 // jewelry : 2015-03-05 Wild Bloom, LLC
@@ -8541,9 +8497,6 @@ kred
 // kuokgroup : 2015-04-09 Kerry Trading Co. Limited
 kuokgroup
 
-// kyknet : 2015-03-05 Electronic Media Network (Pty) Ltd
-kyknet
-
 // kyoto : 2014-11-07 Academic Institution: Kyoto Jyoho Gakuen
 kyoto
 
@@ -8555,6 +8508,9 @@ ladbrokes
 
 // lamborghini : 2015-06-04 Automobili Lamborghini S.p.A.
 lamborghini
+
+// lamer : 2015-10-01 The Estée Lauder Companies Inc.
+lamer
 
 // lancaster : 2015-02-12 LANCASTER
 lancaster
@@ -8745,6 +8701,9 @@ management
 // mango : 2013-10-24 PUNTO FA S.L.
 mango
 
+// map : 2016-06-09 Charleston Road Registry Inc.
+map
+
 // market : 2014-03-06
 market
 
@@ -8805,6 +8764,9 @@ menu
 // meo : 2014-11-07 PT Comunicacoes S.A.
 meo
 
+// merckmsd : 2016-07-14 MSD Registry Holdings, Inc.
+merckmsd
+
 // metlife : 2015-05-07 MetLife Services and Solutions, LLC
 metlife
 
@@ -8835,8 +8797,8 @@ mls
 // mma : 2014-11-07 MMA IARD
 mma
 
-// mnet : 2015-03-05 Electronic Media Network (Pty) Ltd
-mnet
+// mobile : 2016-06-02 Dish DBS Corporation
+mobile
 
 // mobily : 2014-12-18 GreenTech Consultancy Company W.L.L.
 mobily
@@ -8859,6 +8821,9 @@ monash
 // money : 2014-10-16 Outer McCook, LLC
 money
 
+// monster : 2015-09-11 Monster Worldwide, Inc.
+monster
+
 // montblanc : 2014-06-23 Richemont DNS Inc.
 montblanc
 
@@ -8874,7 +8839,7 @@ mortgage
 // moscow : 2013-12-19 Foundation for Assistance for Internet Technologies and Infrastructure Development (FAITID)
 moscow
 
-// moto : 2015-06-04 Charleston Road Registry Inc.
+// moto : 2015-06-04
 moto
 
 // motorcycles : 2014-01-09 DERMotorcycles, LLC
@@ -8901,17 +8866,11 @@ mtpc
 // mtr : 2015-03-12 MTR Corporation Limited
 mtr
 
-// multichoice : 2015-03-12 MultiChoice (Proprietary) Limited
-multichoice
-
 // mutual : 2015-04-02 Northwestern Mutual MU TLD Registry, LLC
 mutual
 
 // mutuelle : 2015-06-18 Fédération Nationale de la Mutualité Française
 mutuelle
-
-// mzansimagic : 2015-03-05 Electronic Media Network (Pty) Ltd
-mzansimagic
 
 // nab : 2015-08-20 National Australia Bank Limited
 nab
@@ -8921,9 +8880,6 @@ nadex
 
 // nagoya : 2013-10-24 GMO Registry, Inc.
 nagoya
-
-// naspers : 2015-02-12 Intelprop (Proprietary) Limited
-naspers
 
 // nationwide : 2015-07-23 Nationwide Mutual Insurance Company
 nationwide
@@ -8954,6 +8910,9 @@ neustar
 
 // new : 2014-01-30 Charleston Road Registry Inc.
 new
+
+// newholland : 2015-09-03 CNH Industrial N.V.
+newholland
 
 // news : 2014-12-18
 news
@@ -8991,6 +8950,9 @@ ninja
 // nissan : 2014-03-27 NISSAN MOTOR CO., LTD.
 nissan
 
+// nissay : 2015-10-29 Nippon Life Insurance Company
+nissay
+
 // nokia : 2015-01-08 Nokia Corporation
 nokia
 
@@ -9024,7 +8986,7 @@ nyc
 // obi : 2014-09-25 OBI Group Holding SE & Co. KGaA
 obi
 
-// observer : 2015-04-30 Guardian News and Media Limited
+// observer : 2015-04-30
 observer
 
 // off : 2015-07-23 Johnson Shareholdings, Inc.
@@ -9081,8 +9043,11 @@ orange
 // organic : 2014-03-27 Afilias Limited
 organic
 
-// orientexpress : 2015-02-05 Belmond Ltd.
+// orientexpress : 2015-02-05
 orientexpress
+
+// origins : 2015-10-01 The Estée Lauder Companies Inc.
+origins
 
 // osaka : 2014-09-04 Interlink Co., Ltd.
 osaka
@@ -9126,8 +9091,8 @@ party
 // passagens : 2015-03-05 Travel Reservations SRL
 passagens
 
-// payu : 2015-02-12 MIH PayU B.V.
-payu
+// pay : 2015-08-27 Amazon EU S.à r.l.
+pay
 
 // pccw : 2015-05-14 PCCW Enterprises Limited
 pccw
@@ -9135,11 +9100,20 @@ pccw
 // pet : 2015-05-07 Afilias plc
 pet
 
+// pfizer : 2015-09-11 Pfizer Inc.
+pfizer
+
 // pharmacy : 2014-06-19 National Association of Boards of Pharmacy
 pharmacy
 
+// phd : 2016-07-28 Charleston Road Registry Inc.
+phd
+
 // philips : 2014-11-07 Koninklijke Philips N.V.
 philips
+
+// phone : 2016-06-02 Dish DBS Corporation
+phone
 
 // photo : 2013-11-14 Uniregistry, Corp.
 photo
@@ -9237,7 +9211,7 @@ prof
 // progressive : 2015-07-23 Progressive Casualty Insurance Company
 progressive
 
-// promo : 2014-12-18 Play.PROMO Oy
+// promo : 2014-12-18
 promo
 
 // properties : 2013-12-05 Big Pass, LLC
@@ -9258,6 +9232,9 @@ prudential
 // pub : 2013-12-12 United TLD Holdco Ltd.
 pub
 
+// pwc : 2015-10-29 PricewaterhouseCoopers LLP
+pwc
+
 // qpon : 2013-11-14 dotCOOL, Inc.
 qpon
 
@@ -9273,11 +9250,17 @@ qvc
 // racing : 2014-12-04 Premier Registry Limited
 racing
 
+// radio : 2016-07-21 European Broadcasting Union (EBU)
+radio
+
 // raid : 2015-07-23 Johnson Shareholdings, Inc.
 raid
 
 // read : 2014-12-18 Amazon EU S.à r.l.
 read
+
+// realestate : 2015-09-11 dotRealEstate LLC
+realestate
 
 // realtor : 2014-05-29 Real Estate Domains LLC
 realtor
@@ -9365,6 +9348,9 @@ rio
 
 // rip : 2014-07-10 United TLD Holdco Ltd.
 rip
+
+// rmit : 2015-11-19 Royal Melbourne Institute of Technology
+rmit
 
 // rocher : 2014-12-18 Ferrero Trading Lux S.A.
 rocher
@@ -9489,14 +9475,23 @@ scor
 // scot : 2014-01-23 Dot Scot Registry Limited
 scot
 
+// search : 2016-06-09 Charleston Road Registry Inc.
+search
+
 // seat : 2014-05-22 SEAT, S.A. (Sociedad Unipersonal)
 seat
+
+// secure : 2015-08-27 Amazon EU S.à r.l.
+secure
 
 // security : 2015-05-14
 security
 
 // seek : 2014-12-04 Seek Limited
 seek
+
+// select : 2015-10-08 iSelect Ltd
+select
 
 // sener : 2014-10-24 Sener Ingeniería y Sistemas, S.A.
 sener
@@ -9522,6 +9517,9 @@ sexy
 // sfr : 2015-08-13 Societe Francaise du Radiotelephone - SFR
 sfr
 
+// shangrila : 2015-09-03 Shangri‐La International Hotel Management Limited
+shangrila
+
 // sharp : 2014-05-01 Sharp Corporation
 sharp
 
@@ -9539,6 +9537,12 @@ shiksha
 
 // shoes : 2013-10-02 Binky Galley, LLC
 shoes
+
+// shop : 2016-04-08 GMO Registry, Inc.
+shop
+
+// shopping : 2016-03-31
+shopping
 
 // shouji : 2015-01-08 QIHOO 360 TECHNOLOGY CO. LTD.
 shouji
@@ -9645,7 +9649,7 @@ staples
 // star : 2015-01-08 Star India Private Limited
 star
 
-// starhub : 2015-02-05 StarHub Limited
+// starhub : 2015-02-05 StarHub Ltd
 starhub
 
 // statebank : 2015-03-12 STATE BANK OF INDIA
@@ -9672,6 +9676,9 @@ storage
 // store : 2015-04-09 DotStore Inc.
 store
 
+// stream : 2016-01-08 dot Stream Limited
+stream
+
 // studio : 2015-02-11
 studio
 
@@ -9683,9 +9690,6 @@ style
 
 // sucks : 2014-12-22 Vox Populi Registry Inc.
 sucks
-
-// supersport : 2015-03-05 SuperSport International Holdings Proprietary Limited
-supersport
 
 // supplies : 2013-12-19 Atomic Fields, LLC
 supplies
@@ -9909,6 +9913,9 @@ ubs
 // uconnect : 2015-07-30 FCA US LLC.
 uconnect
 
+// unicom : 2015-10-15 China United Network Communications Corporation Limited
+unicom
+
 // university : 2014-03-06 Little Station, LLC
 university
 
@@ -9926,6 +9933,9 @@ vacations
 
 // vana : 2014-12-11 Lifestyle Domain Holdings, Inc.
 vana
+
+// vanguard : 2015-09-03 The Vanguard Group, Inc.
+vanguard
 
 // vegas : 2014-01-16 Dot Vegas, Inc.
 vegas
@@ -9992,6 +10002,9 @@ vodka
 
 // volkswagen : 2015-05-14 Volkswagen Group of America Inc.
 volkswagen
+
+// volvo : 2015-11-12 Volvo Holding Sverige Aktiebolag
+volvo
 
 // vote : 2013-11-21 Monolith Registry LLC
 vote
@@ -10101,6 +10114,9 @@ works
 // world : 2014-06-12 Bitter Fields, LLC
 world
 
+// wow : 2015-10-08 Amazon EU S.à r.l.
+wow
+
 // wtc : 2013-12-19 World Trade Centers Association, Inc.
 wtc
 
@@ -10164,6 +10180,9 @@ xin
 // xn--55qx5d : 2013-11-14 Computer Network Information Center of Chinese Academy of Sciences （China Internet Network Information Center）
 公司
 
+// xn--5su34j936bgsg : 2015-09-03 Shangri‐La International Hotel Management Limited
+香格里拉
+
 // xn--5tzm5g : 2014-12-22 Global Website TLD Asia Limited
 网站
 
@@ -10175,6 +10194,9 @@ xin
 
 // xn--80adxhks : 2013-12-19 Foundation for Assistance for Internet Technologies and Infrastructure Development (FAITID)
 москва
+
+// xn--80aqecdr1a : 2015-10-21 Pontificium Consilium de Comunicationibus Socialibus (PCCS) (Pontifical Council for Social Communication)
+католик
 
 // xn--80asehdb : 2013-07-14 CORE Association
 онлайн
@@ -10212,7 +10234,7 @@ xin
 // xn--cg4bki : 2013-09-27 SAMSUNG SDS CO., LTD
 삼성
 
-// xn--czr694b : 2014-01-16 HU YI GLOBAL INFORMATION RESOURCES (HOLDING) COMPANY. HONGKONG LIMITED
+// xn--czr694b : 2014-01-16 Dot Trademark TLD Holding Company Limted
 商标
 
 // xn--czrs0t : 2013-12-19 Wild Island, LLC
@@ -10260,13 +10282,16 @@ xin
 // xn--gckr3f0f : 2015-02-26 Amazon EU S.à r.l.
 クラウド
 
+// xn--gk3at1e : 2015-10-08 Amazon EU S.à r.l.
+通販
+
 // xn--hxt814e : 2014-05-15 Zodiac Libra Limited
 网店
 
 // xn--i1b6b1a6a2e : 2013-11-14 Public Interest Registry
 संगठन
 
-// xn--imr513n : 2014-12-11 HU YI GLOBAL INFORMATION RESOURCES (HOLDING) COMPANY. HONGKONG LIMITED
+// xn--imr513n : 2014-12-11 Dot Trademark TLD Holding Company Limted
 餐厅
 
 // xn--io0a7i : 2013-11-14 Computer Network Information Center of Chinese Academy of Sciences （China Internet Network Information Center）
@@ -10296,6 +10321,9 @@ xin
 // xn--mgba7c0bbn0a : 2015-05-14 Crescent Holding GmbH
 العليان
 
+// xn--mgbaakc7dvf : 2015-09-03 Emirates Telecommunications Corporation (trading as Etisalat)
+اتصالات
+
 // xn--mgbab2bd : 2013-10-31 CORE Association
 بازار
 
@@ -10304,6 +10332,9 @@ xin
 
 // xn--mgbca7dzdo : 2015-07-30 Abu Dhabi Systems and Information Centre
 ابوظبي
+
+// xn--mgbi4ecexp : 2015-10-21 Pontificium Consilium de Comunicationibus Socialibus (PCCS) (Pontifical Council for Social Communication)
+كاثوليك
 
 // xn--mgbt3dhd : 2014-09-04 Asia Green IT System Bilgisayar San. ve Tic. Ltd. Sti.
 همراه
@@ -10319,6 +10350,9 @@ xin
 
 // xn--ngbe9e0a : 2014-12-04 Kuwait Finance House
 بيتك
+
+// xn--ngbrx : 2015-11-12 League of Arab States
+عرب
 
 // xn--nqv7f : 2013-11-14 Public Interest Registry
 机构
@@ -10358,6 +10392,9 @@ xin
 
 // xn--tckwe : 2015-01-15 VeriSign Sarl
 コム
+
+// xn--tiq49xqyj : 2015-10-21 Pontificium Consilium de Comunicationibus Socialibus (PCCS) (Pontifical Council for Social Communication)
+天主教
 
 // xn--unup4y : 2013-07-14 Spring Fields, LLC
 游戏
@@ -10448,61 +10485,147 @@ zuerich
 // ===BEGIN PRIVATE DOMAINS===
 // (Note: these are in alphabetical order by company name)
 
+// Agnat sp. z o.o. : https://domena.pl
+// Submitted by Przemyslaw Plewa <it-admin@domena.pl>
+beep.pl
+
+// Alces Software Ltd : http://alces-software.com
+// Submitted by Mark J. Titorenko <mark.titorenko@alces-software.com>
+*.compute.estate
+*.alces.network
+
+// alwaysdata : https://www.alwaysdata.com
+// Submitted by Cyril <admin@alwaysdata.com>
+*.alwaysdata.net
+
 // Amazon CloudFront : https://aws.amazon.com/cloudfront/
-// Submitted by Donavan Miller <donavanm@amazon.com> 2013-03-22
+// Submitted by Donavan Miller <donavanm@amazon.com>
 cloudfront.net
 
 // Amazon Elastic Compute Cloud: https://aws.amazon.com/ec2/
-// Submitted by Osman Surkatty <osmans@amazon.com> 2014-12-16
-ap-northeast-1.compute.amazonaws.com
-ap-southeast-1.compute.amazonaws.com
-ap-southeast-2.compute.amazonaws.com
-cn-north-1.compute.amazonaws.cn
-compute.amazonaws.cn
-compute.amazonaws.com
-compute-1.amazonaws.com
-eu-west-1.compute.amazonaws.com
-eu-central-1.compute.amazonaws.com
-sa-east-1.compute.amazonaws.com
+// Submitted by Luke Wells <psl-maintainers@amazon.com>
+*.compute.amazonaws.com
+*.compute-1.amazonaws.com
+*.compute.amazonaws.com.cn
 us-east-1.amazonaws.com
-us-gov-west-1.compute.amazonaws.com
-us-west-1.compute.amazonaws.com
-us-west-2.compute.amazonaws.com
-z-1.compute-1.amazonaws.com
-z-2.compute-1.amazonaws.com
 
 // Amazon Elastic Beanstalk : https://aws.amazon.com/elasticbeanstalk/
-// Submitted by Adam Stein <astein@amazon.com> 2013-04-02
-elasticbeanstalk.com
+// Submitted by Luke Wells <psl-maintainers@amazon.com>
+elasticbeanstalk.cn-north-1.amazonaws.com.cn
+*.elasticbeanstalk.com
 
 // Amazon Elastic Load Balancing : https://aws.amazon.com/elasticloadbalancing/
-// Submitted by Scott Vidmar <svidmar@amazon.com> 2013-03-27
-elb.amazonaws.com
+// Submitted by Luke Wells <psl-maintainers@amazon.com>
+*.elb.amazonaws.com
+*.elb.amazonaws.com.cn
 
 // Amazon S3 : https://aws.amazon.com/s3/
-// Submitted by Eric Kinolik <kilo@amazon.com> 2015-04-08
+// Submitted by Luke Wells <psl-maintainers@amazon.com>
 s3.amazonaws.com
 s3-ap-northeast-1.amazonaws.com
+s3-ap-northeast-2.amazonaws.com
+s3-ap-south-1.amazonaws.com
 s3-ap-southeast-1.amazonaws.com
 s3-ap-southeast-2.amazonaws.com
-s3-external-1.amazonaws.com
-s3-external-2.amazonaws.com
-s3-fips-us-gov-west-1.amazonaws.com
+s3-ca-central-1.amazonaws.com
 s3-eu-central-1.amazonaws.com
 s3-eu-west-1.amazonaws.com
+s3-eu-west-2.amazonaws.com
+s3-external-1.amazonaws.com
+s3-fips-us-gov-west-1.amazonaws.com
 s3-sa-east-1.amazonaws.com
 s3-us-gov-west-1.amazonaws.com
+s3-us-east-2.amazonaws.com
 s3-us-west-1.amazonaws.com
 s3-us-west-2.amazonaws.com
+s3.ap-northeast-2.amazonaws.com
+s3.ap-south-1.amazonaws.com
 s3.cn-north-1.amazonaws.com.cn
+s3.ca-central-1.amazonaws.com
 s3.eu-central-1.amazonaws.com
+s3.eu-west-2.amazonaws.com
+s3.us-east-2.amazonaws.com
+s3.dualstack.ap-northeast-1.amazonaws.com
+s3.dualstack.ap-northeast-2.amazonaws.com
+s3.dualstack.ap-south-1.amazonaws.com
+s3.dualstack.ap-southeast-1.amazonaws.com
+s3.dualstack.ap-southeast-2.amazonaws.com
+s3.dualstack.ca-central-1.amazonaws.com
+s3.dualstack.eu-central-1.amazonaws.com
+s3.dualstack.eu-west-1.amazonaws.com
+s3.dualstack.eu-west-2.amazonaws.com
+s3.dualstack.sa-east-1.amazonaws.com
+s3.dualstack.us-east-1.amazonaws.com
+s3.dualstack.us-east-2.amazonaws.com
+s3-website-us-east-1.amazonaws.com
+s3-website-us-west-1.amazonaws.com
+s3-website-us-west-2.amazonaws.com
+s3-website-ap-northeast-1.amazonaws.com
+s3-website-ap-southeast-1.amazonaws.com
+s3-website-ap-southeast-2.amazonaws.com
+s3-website-eu-west-1.amazonaws.com
+s3-website-sa-east-1.amazonaws.com
+s3-website.ap-northeast-2.amazonaws.com
+s3-website.ap-south-1.amazonaws.com
+s3-website.ca-central-1.amazonaws.com
+s3-website.eu-central-1.amazonaws.com
+s3-website.eu-west-2.amazonaws.com
+s3-website.us-east-2.amazonaws.com
+
+// Amune : https://amune.org/
+// Submitted by Team Amune <cert@amune.org>
+t3l3p0rt.net
+tele.amune.org
+
+// Aptible : https://www.aptible.com/
+// Submitted by Thomas Orozco <thomas@aptible.com>
+on-aptible.com
+
+// Asociación Amigos de la Informática "Euskalamiga" : http://encounter.eus/
+// Submitted by Hector Martin <marcan@euskalencounter.org>
+user.party.eus
+
+// Association potager.org : https://potager.org/
+// Submitted by Lunar <jardiniers@potager.org>
+pimienta.org
+poivron.org
+potager.org
+sweetpepper.org
+
+// ASUSTOR Inc. : http://www.asustor.com
+// Submitted by Vincent Tseng <vincenttseng@asustor.com>
+myasustor.com
+
+// AVM : https://avm.de
+// Submitted by Andreas Weise <a.weise@avm.de>
+myfritz.net
+
+// backplane : https://www.backplane.io
+// Submitted by Anthony Voutas <anthony@backplane.io>
+backplaneapp.io
 
 // BetaInABox
-// Submitted by adrian@betainabox.com 2012-09-13
+// Submitted by Adrian <adrian@betainabox.com>
 betainabox.com
 
+// BinaryLane : http://www.binarylane.com
+// Submitted by Nathan O'Sullivan <nathan@mammoth.com.au>
+bnr.la
+
+// Boxfuse : https://boxfuse.com
+// Submitted by Axel Fontaine <axel@boxfuse.com>
+boxfuse.io
+
+// BrowserSafetyMark
+// Submitted by Dave Tharp <browsersafetymark.io@quicinc.com>
+browsersafetymark.io
+
+// callidomus: https://www.callidomus.com/
+// Submitted by Marcus Popp <admin@callidomus.com>
+mycd.eu
+
 // CentralNic : http://www.centralnic.com/names/domains
-// Submitted by registry <gavin.brown@centralnic.com> 2012-09-27
+// Submitted by registry <gavin.brown@centralnic.com>
 ae.org
 ar.com
 br.com
@@ -10533,63 +10656,152 @@ za.bz
 za.com
 
 // Africa.com Web Solutions Ltd : https://registry.africa.com
-// Submitted by Gavin Brown <gavin.brown@centralnic.com> 2014-02-04
+// Submitted by Gavin Brown <gavin.brown@centralnic.com>
 africa.com
 
 // iDOT Services Limited : http://www.domain.gr.com
-// Submitted by Gavin Brown <gavin.brown@centralnic.com> 2014-02-04
+// Submitted by Gavin Brown <gavin.brown@centralnic.com>
 gr.com
 
 // Radix FZC : http://domains.in.net
-// Submitted by Gavin Brown <gavin.brown@centralnic.com> 2014-02-04
+// Submitted by Gavin Brown <gavin.brown@centralnic.com>
 in.net
 
 // US REGISTRY LLC : http://us.org
-// Submitted by Gavin Brown <gavin.brown@centralnic.com> 2014-02-04
+// Submitted by Gavin Brown <gavin.brown@centralnic.com>
 us.org
 
 // co.com Registry, LLC : https://registry.co.com
-// Submitted by Gavin Brown <gavin.brown@centralnic.com> 2014-02-04
+// Submitted by Gavin Brown <gavin.brown@centralnic.com>
 co.com
 
 // c.la : http://www.c.la/
 c.la
 
+// certmgr.org : https://certmgr.org
+// Submitted by B. Blechschmidt <hostmaster@certmgr.org>
+certmgr.org
+
+// Citrix : https://citrix.com
+// Submitted by Alex Stoddard <alex.stoddard@citrix.com>
+xenapponazure.com
+
+// ClearVox : http://www.clearvox.nl/
+// Submitted by Leon Rowland <leon@clearvox.nl>
+virtueeldomein.nl
+
 // cloudControl : https://www.cloudcontrol.com/
-// Submitted by Tobias Wilken <tw@cloudcontrol.com> 2013-07-23
+// Submitted by Tobias Wilken <tw@cloudcontrol.com>
 cloudcontrolled.com
 cloudcontrolapp.com
 
 // co.ca : http://registry.co.ca/
 co.ca
 
+// i-registry s.r.o. : http://www.i-registry.cz/
+// Submitted by Martin Semrad <semrad@i-registry.cz>
+co.cz
+
 // CDN77.com : http://www.cdn77.com
-// Submitted by Jan Krpes <jan.krpes@cdn77.com> 2015-07-13
+// Submitted by Jan Krpes <jan.krpes@cdn77.com>
 c.cdn77.org
 cdn77-ssl.net
 r.cdn77.net
 rsc.cdn77.org
 ssl.origin.cdn77-secure.org
 
+// Cloud DNS Ltd : http://www.cloudns.net
+// Submitted by Aleksander Hristov <noc@cloudns.net>
+cloudns.asia
+cloudns.biz
+cloudns.club
+cloudns.cc
+cloudns.eu
+cloudns.in
+cloudns.info
+cloudns.org
+cloudns.pro
+cloudns.pw
+cloudns.us
+
 // CoDNS B.V.
 co.nl
 co.no
 
 // Commerce Guys, SAS
-// Submitted by Damien Tournoud <damien@commerceguys.com> 2015-01-22
+// Submitted by Damien Tournoud <damien@commerceguys.com>
 *.platform.sh
 
+// COSIMO GmbH http://www.cosimo.de
+// Submitted by Rene Marticke <rmarticke@cosimo.de>
+dyn.cosidns.de
+dynamisches-dns.de
+dnsupdater.de
+internet-dns.de
+l-o-g-i-n.de
+dynamic-dns.info
+feste-ip.net
+knx-server.net
+static-access.net
+
+// Craynic, s.r.o. : http://www.craynic.com/
+// Submitted by Ales Krajnik <ales.krajnik@craynic.com>
+realm.cz
+
+// Cryptonomic : https://cryptonomic.net/
+// Submitted by Andrew Cady <public-suffix-list@cryptonomic.net>
+*.cryptonomic.net
+
 // Cupcake : https://cupcake.io/
-// Submitted by Jonathan Rudenberg <jonathan@cupcake.io> 2013-10-08
+// Submitted by Jonathan Rudenberg <jonathan@cupcake.io>
 cupcake.is
 
+// cyon GmbH : https://www.cyon.ch/
+// Submitted by Dominic Luechinger <dol@cyon.ch>
+cyon.link
+cyon.site
+
+// Daplie, Inc : https://daplie.com
+// Submitted by AJ ONeal <aj@daplie.com>
+daplie.me
+
+// Dansk.net : http://www.dansk.net/
+// Submitted by Anani Voule <digital@digital.co.dk>
+biz.dk
+co.dk
+firm.dk
+reg.dk
+store.dk
+
+// deSEC : https://desec.io/
+// Submitted by Peter Thomassen <peter@desec.io>
+dedyn.io
+
+// DNShome : https://www.dnshome.de/
+// Submitted by Norbert Auler <mail@dnshome.de>
+dnshome.de
+
 // DreamHost : http://www.dreamhost.com/
-// Submitted by Andrew Farmer <andrew.farmer@dreamhost.com> 2012-10-02
+// Submitted by Andrew Farmer <andrew.farmer@dreamhost.com>
 dreamhosters.com
 
+// Drobo : http://www.drobo.com/
+// Submitted by Ricardo Padilha <rpadilha@drobo.com>
+mydrobo.com
+
+// Drud Holdings, LLC. : https://www.drud.com/
+// Submitted by Kevin Bridges <kevin@drud.com>
+drud.io
+drud.us
+
 // DuckDNS : http://www.duckdns.org/
-// Submitted by Richard Harper <richard@duckdns.org> 2015-05-17
+// Submitted by Richard Harper <richard@duckdns.org>
 duckdns.org
+
+// dy.fi : http://dy.fi/
+// Submitted by Heikki Hannikainen <hessu@hes.iki.fi>
+dy.fi
+tunk.org
 
 // DynDNS.com : http://www.dyndns.com/services/dns/dyndns/
 dyndns-at-home.com
@@ -10872,9 +11084,33 @@ webhop.org
 worse-than.tv
 writesthisblog.com
 
-// EU.org https://eu.org/
-// Submitted by Pierre Beyssac <hostmaster@eu.org> 2015-04-17
+// ddnss.de : https://www.ddnss.de/
+// Submitted by Robert Niedziela <webmaster@ddnss.de>
+ddnss.de
+dyn.ddnss.de
+dyndns.ddnss.de
+dyndns1.de
+dyn-ip24.de
+home-webserver.de
+dyn.home-webserver.de
+myhome-server.de
+ddnss.org
 
+// dynv6 : https://dynv6.com
+// Submitted by Dominik Menke <dom@digineo.de> 2016-01-18
+dynv6.net
+
+// E4YOU spol. s.r.o. : https://e4you.cz/
+// Submitted by Vladimir Dudr <info@e4you.cz>
+e4.cz
+
+// Enonic : http://enonic.com/
+// Submitted by Erik Kaareng-Sunde <esu@enonic.com>
+enonic.io
+customer.enonic.io
+
+// EU.org https://eu.org/
+// Submitted by Pierre Beyssac <hostmaster@eu.org>
 eu.org
 al.eu.org
 asso.eu.org
@@ -10932,37 +11168,171 @@ tr.eu.org
 uk.eu.org
 us.eu.org
 
-// Fastly Inc. http://www.fastly.com/
-// Submitted by Vladimir Vuksan <vladimir@fastly.com> 2013-05-31
+// Evennode : http://www.evennode.com/
+// Submitted by Michal Kralik <support@evennode.com>
+eu-1.evennode.com
+eu-2.evennode.com
+us-1.evennode.com
+us-2.evennode.com
+
+// Facebook, Inc.
+// Submitted by Peter Ruibal <public-suffix@fb.com>
+apps.fbsbx.com
+
+// FAITID : https://faitid.org/
+// Submitted by Maxim Alzoba <tech.contact@faitid.org>
+// https://www.flexireg.net/stat_info
+ru.net
+adygeya.ru
+bashkiria.ru
+bir.ru
+cbg.ru
+com.ru
+dagestan.ru
+grozny.ru
+kalmykia.ru
+kustanai.ru
+marine.ru
+mordovia.ru
+msk.ru
+mytis.ru
+nalchik.ru
+nov.ru
+pyatigorsk.ru
+spb.ru
+vladikavkaz.ru
+vladimir.ru
+abkhazia.su
+adygeya.su
+aktyubinsk.su
+arkhangelsk.su
+armenia.su
+ashgabad.su
+azerbaijan.su
+balashov.su
+bashkiria.su
+bryansk.su
+bukhara.su
+chimkent.su
+dagestan.su
+east-kazakhstan.su
+exnet.su
+georgia.su
+grozny.su
+ivanovo.su
+jambyl.su
+kalmykia.su
+kaluga.su
+karacol.su
+karaganda.su
+karelia.su
+khakassia.su
+krasnodar.su
+kurgan.su
+kustanai.su
+lenug.su
+mangyshlak.su
+mordovia.su
+msk.su
+murmansk.su
+nalchik.su
+navoi.su
+north-kazakhstan.su
+nov.su
+obninsk.su
+penza.su
+pokrovsk.su
+sochi.su
+spb.su
+tashkent.su
+termez.su
+togliatti.su
+troitsk.su
+tselinograd.su
+tula.su
+tuva.su
+vladikavkaz.su
+vladimir.su
+vologda.su
+
+// Fastly Inc. : http://www.fastly.com/
+// Submitted by Fastly Security <security@fastly.com>
+map.fastly.net
+a.prod.fastly.net
+global.prod.fastly.net
 a.ssl.fastly.net
 b.ssl.fastly.net
 global.ssl.fastly.net
-a.prod.fastly.net
-global.prod.fastly.net
+fastlylb.net
+map.fastlylb.net
+
+// Featherhead : https://featherhead.xyz/
+// Submitted by Simon Menke <simon@featherhead.xyz>
+fhapp.xyz
 
 // Firebase, Inc.
-// Submitted by Chris Raynor <chris@firebase.com> 2014-01-21
+// Submitted by Chris Raynor <chris@firebase.com>
 firebaseapp.com
 
 // Flynn : https://flynn.io
-// Submitted by Jonathan Rudenberg <jonathan@flynn.io> 2014-07-12
+// Submitted by Jonathan Rudenberg <jonathan@flynn.io>
 flynnhub.com
 
+// Freebox : http://www.freebox.fr
+// Submitted by Romain Fliedel <rfliedel@freebox.fr>
+freebox-os.com
+freeboxos.com
+fbx-os.fr
+fbxos.fr
+freebox-os.fr
+freeboxos.fr
+
+// Fusion Intranet : https://www.fusion-intranet.com
+// Submitted by Matthias Burtscher <matthias.burtscher@fusonic.net>
+myfusion.cloud
+
+// Futureweb OG : http://www.futureweb.at
+// Submitted by Andreas Schnederle-Wagner <schnederle@futureweb.at>
+futurehosting.at
+futuremailing.at
+*.ex.ortsinfo.at
+*.kunden.ortsinfo.at
+*.statics.cloud
+
 // GDS : https://www.gov.uk/service-manual/operations/operating-servicegovuk-subdomains
-// Submitted by David Illsley <david.illsley@digital.cabinet-office.gov.uk> 2014-08-28
+// Submitted by David Illsley <david.illsley@digital.cabinet-office.gov.uk>
 service.gov.uk
 
 // GitHub, Inc.
-// Submitted by Ben Toews <btoews@github.com> 2014-02-06
+// Submitted by Patrick Toomey <security@github.com>
 github.io
 githubusercontent.com
+githubcloud.com
+*.api.githubcloud.com
+*.ext.githubcloud.com
+gist.githubcloud.com
+*.githubcloudusercontent.com
+
+// GitLab, Inc.
+// Submitted by Alex Hanselka <alex@gitlab.com>
+gitlab.io
+
+// UKHomeOffice : https://www.gov.uk/government/organisations/home-office
+// Submitted by Jon Shanks <jon.shanks@digital.homeoffice.gov.uk>
+homeoffice.gov.uk
 
 // GlobeHosting, Inc.
-// Submitted by Zoltan Egresi <egresi@globehosting.com> 2013-07-12
-ro.com
+// Submitted by Zoltan Egresi <egresi@globehosting.com>
+ro.im
+shop.ro
+
+// GoIP DNS Services : http://www.goip.de
+// Submitted by Christian Poulter <milchstrasse@goip.de>
+goip.de
 
 // Google, Inc.
-// Submitted by Eduardo Vela <evn@google.com> 2014-12-19
+// Submitted by Eduardo Vela <evn@google.com>
+*.0emm.com
 appspot.com
 blogspot.ae
 blogspot.al
@@ -11038,62 +11408,252 @@ blogspot.td
 blogspot.tw
 blogspot.ug
 blogspot.vn
+cloudfunctions.net
 codespot.com
 googleapis.com
 googlecode.com
 pagespeedmobilizer.com
+publishproxy.com
 withgoogle.com
 withyoutube.com
 
+// Hashbang : https://hashbang.sh
+hashbang.sh
+
+// Hasura : https://hasura.io
+// Submitted by Shahidh K Muhammed <shahidh@hasura.io>
+hasura-app.io
+
+// Hepforge : https://www.hepforge.org
+// Submitted by David Grellscheid <admin@hepforge.org>
+hepforge.org
+
 // Heroku : https://www.heroku.com/
-// Submitted by Tom Maher <tmaher@heroku.com> 2013-05-02
+// Submitted by Tom Maher <tmaher@heroku.com>
 herokuapp.com
 herokussl.com
 
 // iki.fi
-// Submitted by Hannu Aronsson <haa@iki.fi> 2009-11-05
+// Submitted by Hannu Aronsson <haa@iki.fi>
 iki.fi
 
 // info.at : http://www.info.at/
 biz.at
 info.at
 
+// Interlegis : http://www.interlegis.leg.br
+// Submitted by Gabriel Ferreira <registrobr@interlegis.leg.br>
+ac.leg.br
+al.leg.br
+am.leg.br
+ap.leg.br
+ba.leg.br
+ce.leg.br
+df.leg.br
+es.leg.br
+go.leg.br
+ma.leg.br
+mg.leg.br
+ms.leg.br
+mt.leg.br
+pa.leg.br
+pb.leg.br
+pe.leg.br
+pi.leg.br
+pr.leg.br
+rj.leg.br
+rn.leg.br
+ro.leg.br
+rr.leg.br
+rs.leg.br
+sc.leg.br
+se.leg.br
+sp.leg.br
+to.leg.br
+
+// Joyent : https://www.joyent.com/
+// Submitted by Brian Bennett <brian.bennett@joyent.com>
+*.triton.zone
+*.cns.joyent.com
+
+// JS.ORG : http://dns.js.org
+// Submitted by Stefan Keim <admin@js.org>
+js.org
+
+// Keyweb AG : https://www.keyweb.de
+// Submitted by Martin Dannehl <postmaster@keymachine.de>
+keymachine.de
+
+// KnightPoint Systems, LLC : http://www.knightpoint.com/
+// Submitted by Roy Keene <rkeene@knightpoint.com>
+knightpoint.systems
+
+// .KRD : http://nic.krd/data/krd/Registration%20Policy.pdf
+co.krd
+edu.krd
+
+// Magento Commerce
+// Submitted by Damien Tournoud <dtournoud@magento.cloud>
+*.magentosite.cloud
+
+// Meteor Development Group : https://www.meteor.com/hosting
+// Submitted by Pierre Carrier <pierre@meteor.com>
+meteorapp.com
+eu.meteorapp.com
+
 // Michau Enterprises Limited : http://www.co.pl/
 co.pl
 
 // Microsoft : http://microsoft.com
-// Submitted by Barry Dorrans <bdorrans@microsoft.com> 2014-01-24
+// Submitted by Barry Dorrans <bdorrans@microsoft.com>
 azurewebsites.net
 azure-mobile.net
 cloudapp.net
 
 // Mozilla Foundation : https://mozilla.org/
-// Submited by glob <glob@mozilla.com> 2015-07-06
+// Submitted by glob <glob@mozilla.com>
 bmoattachments.org
 
 // Neustar Inc.
-// Submitted by Trung Tran <Trung.Tran@neustar.biz> 2015-04-23
+// Submitted by Trung Tran <Trung.Tran@neustar.biz>
 4u.com
 
+// ngrok : https://ngrok.com/
+// Submitted by Alan Shreve <alan@ngrok.com>
+ngrok.io
+
 // NFSN, Inc. : https://www.NearlyFreeSpeech.NET/
-// Submitted by Jeff Wheelhouse <support@nearlyfreespeech.net> 2014-02-02
+// Submitted by Jeff Wheelhouse <support@nearlyfreespeech.net>
 nfshost.com
 
+// nsupdate.info : https://www.nsupdate.info/
+// Submitted by Thomas Waldmann <info@nsupdate.info>
+nsupdate.info
+nerdpol.ovh
+
+// No-IP.com : https://noip.com/
+// Submitted by Deven Reza <publicsuffixlist@noip.com>
+blogsyte.com
+brasilia.me
+cable-modem.org
+ciscofreak.com
+collegefan.org
+couchpotatofries.org
+damnserver.com
+ddns.me
+ditchyourip.com
+dnsfor.me
+dnsiskinky.com
+dvrcam.info
+dynns.com
+eating-organic.net
+fantasyleague.cc
+geekgalaxy.com
+golffan.us
+health-carereform.com
+homesecuritymac.com
+homesecuritypc.com
+hopto.me
+ilovecollege.info
+loginto.me
+mlbfan.org
+mmafan.biz
+myactivedirectory.com
+mydissent.net
+myeffect.net
+mymediapc.net
+mypsx.net
+mysecuritycamera.com
+mysecuritycamera.net
+mysecuritycamera.org
+net-freaks.com
+nflfan.org
+nhlfan.net
+no-ip.ca
+no-ip.co.uk
+no-ip.net
+noip.us
+onthewifi.com
+pgafan.net
+point2this.com
+pointto.us
+privatizehealthinsurance.net
+quicksytes.com
+read-books.org
+securitytactics.com
+serveexchange.com
+servehumour.com
+servep2p.com
+servesarcasm.com
+stufftoread.com
+ufcfan.org
+unusualperson.com
+workisboring.com
+3utilities.com
+bounceme.net
+ddns.net
+ddnsking.com
+gotdns.ch
+hopto.org
+myftp.biz
+myftp.org
+myvnc.com
+no-ip.biz
+no-ip.info
+no-ip.org
+noip.me
+redirectme.net
+servebeer.com
+serveblog.net
+servecounterstrike.com
+serveftp.com
+servegame.com
+servehalflife.com
+servehttp.com
+serveirc.com
+serveminecraft.net
+servemp3.com
+servepics.com
+servequake.com
+sytes.net
+webhop.me
+zapto.org
+
 // NYC.mn : http://www.information.nyc.mn
-// Submitted by Matthew Brown <mattbrown@nyc.mn> 2013-03-11
+// Submitted by Matthew Brown <mattbrown@nyc.mn>
 nyc.mn
 
 // One Fold Media : http://www.onefoldmedia.com/
-// Submitted by Eddie Jones <eddie@onefoldmedia.com> 2014-06-10
+// Submitted by Eddie Jones <eddie@onefoldmedia.com>
 nid.io
 
+// OpenCraft GmbH : http://opencraft.com/
+// Submitted by Sven Marnach <sven@opencraft.com>
+opencraft.hosting
+
 // Opera Software, A.S.A.
-// Submitted by Yngve Pettersen <yngve@opera.com> 2009-11-26
+// Submitted by Yngve Pettersen <yngve@opera.com>
 operaunite.com
 
 // OutSystems
-// Submitted by Duarte Santos <domain-admin@outsystemscloud.com> 2014-03-11
+// Submitted by Duarte Santos <domain-admin@outsystemscloud.com>
 outsystemscloud.com
+
+// OwnProvider : http://www.ownprovider.com
+// Submitted by Jan Moennich <jan.moennich@ownprovider.com>
+ownprovider.com
+
+// oy.lc
+// Submitted by Charly Coste <changaco@changaco.oy.lc>
+oy.lc
+
+// Pagefog : https://pagefog.com/
+// Submitted by Derek Myers <derek@pagefog.com>
+pgfog.com
+
+// Pagefront : https://www.pagefronthq.com/
+// Submitted by Jason Kriss <jason@pagefronthq.com>
+pagefrontapp.com
 
 // .pl domains (grandfathered)
 art.pl
@@ -11103,33 +11663,152 @@ poznan.pl
 wroc.pl
 zakopane.pl
 
+// Pantheon Systems, Inc. : https://pantheon.io/
+// Submitted by Gary Dylina <gary@pantheon.io>
+pantheonsite.io
+gotpantheon.com
+
+// Peplink | Pepwave : http://peplink.com/
+// Submitted by Steve Leung <steveleung@peplink.com>
+mypep.link
+
+// Planet-Work : https://www.planet-work.com/
+// Submitted by Frédéric VANNIÈRE <f.vanniere@planet-work.com>
+on-web.fr
+
+// prgmr.com : https://prgmr.com/
+// Submitted by Sarah Newman <owner@prgmr.com>
+xen.prgmr.com
+
 // priv.at : http://www.nic.priv.at/
-// Submitted by registry <lendl@nic.at> 2008-06-09
+// Submitted by registry <lendl@nic.at>
 priv.at
 
+// Protonet GmbH : http://protonet.io
+// Submitted by Martin Meier <admin@protonet.io>
+protonet.io
+
+// Publication Presse Communication SARL : https://ppcom.fr
+// Submitted by Yaacov Akiba Slama <admin@chirurgiens-dentistes-en-france.fr>
+chirurgiens-dentistes-en-france.fr
+
 // QA2
-// Submitted by Daniel Dent (https://www.danieldent.com/) 2015-07-16
+// Submitted by Daniel Dent (https://www.danieldent.com/)
 qa2.com
 
+// QNAP System Inc : https://www.qnap.com
+// Submitted by Nick Chang <nickchang@qnap.com>
+dev-myqnapcloud.com
+alpha-myqnapcloud.com
+myqnapcloud.com
+
+// Rackmaze LLC : https://www.rackmaze.com
+// Submitted by Kirill Pertsev <kika@rackmaze.com>
+rackmaze.com
+rackmaze.net
+
 // Red Hat, Inc. OpenShift : https://openshift.redhat.com/
-// Submitted by Tim Kramer <tkramer@rhcloud.com> 2012-10-24
+// Submitted by Tim Kramer <tkramer@rhcloud.com>
 rhcloud.com
 
+// RethinkDB : https://www.rethinkdb.com/
+// Submitted by Chris Kastorff <info@rethinkdb.com>
+hzc.io
+
+// Revitalised Limited : http://www.revitalised.co.uk
+// Submitted by Jack Price <jack@revitalised.co.uk>
+wellbeingzone.eu
+ptplus.fit
+wellbeingzone.co.uk
+
 // Sandstorm Development Group, Inc. : https://sandcats.io/
-// Submitted by Asheesh Laroia <asheesh@sandstorm.io> 2015-07-21
+// Submitted by Asheesh Laroia <asheesh@sandstorm.io>
 sandcats.io
 
+// SBE network solutions GmbH : https://www.sbe.de/
+// Submitted by Norman Meilick <nm@sbe.de>
+logoip.de
+logoip.com
+
+// Securepoint GmbH : https://www.securepoint.de
+// Submitted by Erik Anders <erik.anders@securepoint.de>
+firewall-gateway.com
+firewall-gateway.de
+my-gateway.de
+my-router.de
+spdns.de
+spdns.eu
+firewall-gateway.net
+my-firewall.org
+myfirewall.org
+spdns.org
+
 // Service Online LLC : http://drs.ua/
-// Submitted by Serhii Bulakh <support@drs.ua> 2015-07-30
+// Submitted by Serhii Bulakh <support@drs.ua>
 biz.ua
 co.ua
 pp.ua
 
+// ShiftEdit : https://shiftedit.net/
+// Submitted by Adam Jimenez <adam@shiftcreate.com>
+shiftedit.io
+
+// Shopblocks : http://www.shopblocks.com/
+// Submitted by Alex Bowers <alex@shopblocks.com>
+myshopblocks.com
+
 // SinaAppEngine : http://sae.sina.com.cn/
-// Submitted by SinaAppEngine <saesupport@sinacloud.com> 2015-02-02
+// Submitted by SinaAppEngine <saesupport@sinacloud.com>
+1kapp.com
+appchizi.com
+applinzi.com
 sinaapp.com
 vipsinaapp.com
-1kapp.com
+
+// Skyhat : http://www.skyhat.io
+// Submitted by Shante Adam <shante@skyhat.io>
+bounty-full.com
+alpha.bounty-full.com
+beta.bounty-full.com
+
+// staticland : https://static.land
+// Submitted by Seth Vincent <sethvincent@gmail.com>
+static.land
+dev.static.land
+sites.static.land
+
+// SourceLair PC : https://www.sourcelair.com
+// Submitted by Antonis Kalipetis <akalipetis@sourcelair.com>
+apps.lair.io
+*.stolos.io
+
+// SpaceKit : https://www.spacekit.io/
+// Submitted by Reza Akhavan <spacekit.io@gmail.com>
+spacekit.io
+
+// Stackspace : https://www.stackspace.io/
+// Submitted by Lina He <info@stackspace.io>
+stackspace.space
+
+// Synology, Inc. : https://www.synology.com/
+// Submitted by Rony Weng <ronyweng@synology.com>
+diskstation.me
+dscloud.biz
+dscloud.me
+dscloud.mobi
+dsmynas.com
+dsmynas.net
+dsmynas.org
+familyds.com
+familyds.net
+familyds.org
+i234.me
+myds.me
+synology.me
+
+// TAIFUN Software AG : http://taifun-software.de
+// Submitted by Bjoern Henke <dev-server@taifun-software.de>
+taifun-dns.de
 
 // TASK geographical domains (www.task.gda.pl/uslugi/dns)
 gda.pl
@@ -11138,20 +11817,87 @@ gdynia.pl
 med.pl
 sopot.pl
 
+// TownNews.com : http://www.townnews.com
+// Submitted by Dustin Ward <dward@townnews.com>
+bloxcms.com
+townnews-staging.com
+
+// TransIP : htts://www.transip.nl
+// Submitted by Rory Breuk <rbreuk@transip.nl>
+*.transurl.be
+*.transurl.eu
+*.transurl.nl
+
+// TuxFamily : http://tuxfamily.org
+// Submitted by TuxFamily administrators <adm@staff.tuxfamily.org>
+tuxfamily.org
+
+// TwoDNS : https://www.twodns.de/
+// Submitted by TwoDNS-Support <support@two-dns.de>
+dd-dns.de
+diskstation.eu
+diskstation.org
+dray-dns.de
+draydns.de
+dyn-vpn.de
+dynvpn.de
+mein-vigor.de
+my-vigor.de
+my-wan.de
+syno-ds.de
+synology-diskstation.de
+synology-ds.de
+
 // UDR Limited : http://www.udr.hk.com
-// Submitted by registry <hostmaster@udr.hk.com> 2014-11-07
+// Submitted by registry <hostmaster@udr.hk.com>
 hk.com
 hk.org
 ltd.hk
 inc.hk
 
+// .US
+// Submitted by Ed Moore <Ed.Moore@lib.de.us>
+lib.de.us
+
+// Viprinet Europe GmbH : http://www.viprinet.com
+// Submitted by Simon Kissel <hostmaster@viprinet.com>
+router.management
+
+// Western Digital Technologies, Inc : https://www.wdc.com
+// Submitted by Jung Jin <jungseok.jin@wdc.com>
+remotewd.com
+
+// Wikimedia Labs : https://wikitech.wikimedia.org
+// Submitted by Yuvi Panda <yuvipanda@wikimedia.org>
+wmflabs.org
+
 // Yola : https://www.yola.com/
-// Submitted by Stefano Rivera <stefano@yola.com> 2014-07-09
+// Submitted by Stefano Rivera <stefano@yola.com>
 yolasite.com
 
+// Yombo : https://yombo.net
+// Submitted by Mitch Schwenk <mitch@yombo.net>
+ybo.faith
+yombo.me
+homelink.one
+ybo.party
+ybo.review
+ybo.science
+ybo.trade
+
 // ZaNiC : http://www.za.net/
-// Submitted by registry <hostmaster@nic.za.net> 2009-10-03
+// Submitted by registry <hostmaster@nic.za.net>
 za.net
 za.org
+
+// Zeit, Inc. : https://zeit.domains/
+// Submitted by Olli Vanhoja <olli@zeit.co>
+now.sh
+
+// 1GB LLC : https://www.1gb.ua/
+// Submitted by 1GB LLC <noc@1gb.com.ua>
+cc.ua
+inf.ua
+ltd.ua
 
 // ===END PRIVATE DOMAINS===

--- a/t/01.Policy.t
+++ b/t/01.Policy.t
@@ -166,7 +166,7 @@ sub test_parse {
         "parse, warns of invalid DMARC record format"
     );
 
-     is_deeply(
+    is_deeply(
         $pol->parse(
             'domain=tnpi.net;v=DMARC1;p=reject;rua=mailto:dmarc-feedback@theartfarm.com;pct=;ruf=mailto:dmarc-feedback@theartfarm.com'
         ),
@@ -177,6 +177,13 @@ sub test_parse {
         },
         "parse, warns of invalid DMARC record format, with location"
     );
+
+    $pol = $pol->parse('v=DMARC1');
+    isa_ok( $pol, 'Mail::DMARC::Policy' );
+    $expected = {
+        v   => 'DMARC1'
+    };
+    is_deeply( $pol, $expected, 'parse');
 }
 
 sub test_is_valid_p {

--- a/t/04.PurePerl.t
+++ b/t/04.PurePerl.t
@@ -129,28 +129,28 @@ sub test_external_report {
     my @test_doms = qw/ example.com silly.com /;
     foreach my $dom (@test_doms) {
 
-        my $policy = $dmarc->policy->parse('v=DMARC1; p=none');
+        my $policy = $dmarc->policy->parse('v=DMARC1');
         $policy->{domain} = $dom;
         ok( $policy, "new policy" );
         $dmarc->result->published($policy);
 
         my $uri = URI->new("mailto:test\@$dom");
 
-        #       warn "path: " . $uri->path;
+        # warn "path: " . $uri->path;
         ok( $uri, "new URI" );
         ok( !$dmarc->external_report($uri),
             "external_report, $uri for $dom" );
     }
 
     foreach my $dom (@test_doms) {
-        my $policy = $dmarc->policy->parse('v=DMARC1; p=none');
+        my $policy = $dmarc->policy->parse('v=DMARC1');
         $policy->{domain} = "$dom.com";
         ok( $policy, "new policy" );
         $dmarc->result->published($policy);
 
         my $uri = URI->new("mailto:test\@$dom");
 
-        #       warn "path: " . $uri->path;
+        # warn "path: " . $uri->path;
         ok( $uri, "new URI" );
         ok( $dmarc->external_report($uri),
             "external_report, $uri for $dom.com"

--- a/t/perlcritic.rc
+++ b/t/perlcritic.rc
@@ -1,4 +1,4 @@
-severity = harsh
+severity = stern
 ; gentle stern harsh cruel brutal
 
 verbose  = [%p] %m at line %l, column %c.  %e.  (Severity: %s)\n


### PR DESCRIPTION
- `policy->parse` callers need policy validity need call validate themselves.
- callers that need no valid policy (external reporting) skip validation

fixes #105
fixed #88 