### PR TITLE
Fix init to unset more transient variables

### DIFF
--- a/lib/Mail/DMARC/PurePerl.pm
+++ b/lib/Mail/DMARC/PurePerl.pm
@@ -12,9 +12,14 @@ sub init {
     $self->is_subdomain(0);
     $self->{header_from} = undef;
     $self->{header_from_raw} = undef;
+    $self->{envelope_to} = undef;
+    $self->{envelope_from} = undef;
+    $self->{source_ip} = undef;
     $self->{policy} = undef;
     $self->{result} = undef;
     $self->{report} = undef;
+    $self->{spf} = undef;
+    $self->{dkim} = undef;
     return;
 }
 


### PR DESCRIPTION
This fixes problem with qpsmtpd-prefork. Variables from previous transactions would be retained and caused mysterious DMARC validation errors.