### PR TITLE
Ignore the case of tag keys when parsing DMARC record

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 
 {{$NEXT}}
 
+1.20170906 2017-09-06 Australia/Melbourne
+ - Ignore the case of tag keys when parsing DMARC records
+
 1.20170222 2017-02-21 America/Los_Angeles
 
  - Ensure entities in XML agg reports are properly escaped #104

--- a/lib/Mail/DMARC/Policy.pm
+++ b/lib/Mail/DMARC/Policy.pm
@@ -50,7 +50,7 @@ sub parse {
             $warned++;
             next;
         }
-        $policy{$tag} = $value;
+        $policy{lc $tag} = $value;
     }
     return bless \%policy, ref $self;    # inherited defaults + overrides
 }


### PR DESCRIPTION
V=DMARC1 has been seen in the wild, and is failing validation.