### PR TITLE
Use C locale when generating report date

### DIFF
--- a/lib/Mail/DMARC/Report/Send/SMTP.pm
+++ b/lib/Mail/DMARC/Report/Send/SMTP.pm
@@ -226,8 +226,12 @@ sub assemble_message {
 sub get_timestamp_rfc2822 {
     my ($self, @args) = @_;
     my @ts = scalar @args ? @args : localtime;
-    return POSIX::strftime( '%a, %d %b %Y %H:%M:%S %z', @ts );
-};
+    my $locale = setlocale(LC_CTYPE);
+    setlocale(LC_ALL, 'C');
+    my $timestamp = POSIX::strftime( '%a, %d %b %Y %H:%M:%S %z', @ts );
+    setlocale(LC_ALL, $locale);
+    return $timestamp;
+}
 
 sub get_helo_hostname {
     my $self = shift;


### PR DESCRIPTION
Reported by A. Schulze

I was just pointed to the fact the aggregated reports I sent via email have a wrong formatted date header. after some investigation I guess I found a possible point to fix that:

my header:
Date: Mi, 30 Aug 2017 06:32:51 +0200
expected:
Date: Wed, 30 Aug 2017 06:32:51 +0200