### PR TITLE
Workaround starttls bug in Net::SMTPS

### DIFF
--- a/lib/Mail/DMARC/Report/Send/SMTP.pm
+++ b/lib/Mail/DMARC/Report/Send/SMTP.pm
@@ -64,14 +64,21 @@ sub connect_smtp_tls {
         Timeout         => 12,
         Port            => $self->config->{smtp}{smarthost} ? 587 : 25,
         Hello           => $self->get_helo_hostname,
-        doSSL           => 'starttls',
-        SSL_verify_mode => 0,
         Debug           => $self->verbose ? 1 : 0,
         )
         or do {
             warn "SSL connection failed\n"; ## no critic (Carp)
             return;
         };
+
+    my $tls_supported = $smtp->supports('STARTTLS');
+    if ( defined ( $tls_supported ) ) {
+        $smtp->starttls();
+    }
+    else {
+        warn "server does not support STARTTLS\n"; ## no critic (Carp)
+        return;
+    }
 
     my $c = $self->config->{smtp};
     if ( $c->{smarthost} && $c->{smartuser} && $c->{smartpass} ) {


### PR DESCRIPTION
There appears to be a bug in later versions of Net::SMTPS which prevent starttls from working.

Looks like it is around the $obj->supports('STARTTLS') call, which returns empty string and so evaluates to false.

This patch works around the issue by calling starttls on the Net::SMTP object directly.