### PR TITLE
Check author_id when saving a new report

### DIFF
--- a/lib/Mail/DMARC/Report/Store/SQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL.pm
@@ -172,8 +172,8 @@ sub get_report_id {
     # Reports submitted by our local MTA will not have a report ID
     # They aggregate on the From domain, where the DMARC policy was discovered
         $ids = $self->query(
-        'SELECT id FROM report WHERE from_domain_id=? AND end > ?',
-        [ $from_dom_id, time ]
+        'SELECT id FROM report WHERE from_domain_id=? AND end > ? AND author_id=?',
+        [ $from_dom_id, time, $author_id ]
         );
     };
 


### PR DESCRIPTION
When saving a report record into a database with existing reports from multiple authors we were not checking the author_id when searching for an existing report, so new report records could be saved against a report with the incorrect author id.