### PR TITLE
Build reports as required rather than up front

### DIFF
--- a/bin/dmarc_send_reports
+++ b/bin/dmarc_send_reports
@@ -59,12 +59,11 @@ if ( $report->config->{report_sign}->{keyfile} ) {
 
 local $SIG{'ALRM'} = sub{ die "timeout\n" };
 
-my $todo_reports = $report->store->retrieve_todo();
 my $batch_do = 1;
 
 # 1. get reports, one at a time
 REPORT:
-foreach my $aggregate ( @{ $todo_reports } ) {
+while ( my $aggregate = $report->store->next_todo() ) {
 
     eval {
         send_single_report( $aggregate, $report );

--- a/lib/Mail/DMARC/Report/Store.pm
+++ b/lib/Mail/DMARC/Report/Store.pm
@@ -22,6 +22,11 @@ sub retrieve {
     return $self->backend->retrieve(@_);
 }
 
+sub next_todo {
+    my $self = shift;
+    return $self->backend->next_todo(@_);
+}
+
 sub retrieve_todo {
     my $self = shift;
     return $self->backend->retrieve_todo(@_);

--- a/lib/Mail/DMARC/Report/Store/SQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL.pm
@@ -73,6 +73,32 @@ sub retrieve {
     return $reports;
 }
 
+sub next_todo {
+    my ( $self ) = @_;
+
+    if ( ! exists $self->{ _todo_list } ) {
+        $self->{_todo_list} = $self->query( $self->get_todo_query, [ time ] );
+        return if ! $self->{_todo_list};
+    }
+
+    my $next_todo = shift @{ $self->{_todo_list} };
+    if ( ! $next_todo ) {
+        delete $self->{_todo_list};
+        return;
+    }
+
+    my $agg = Mail::DMARC::Report::Aggregate->new();
+    $self->populate_agg_metadata( \$agg, \$next_todo );
+
+    my $pp = $self->get_report_policy_published( $next_todo->{rid} );
+    $pp->{domain} = $next_todo->{from_domain};
+    $agg->policy_published( Mail::DMARC::Policy->new( %$pp ) );
+
+    $self->populate_agg_records( \$agg, $next_todo->{rid} );
+    return $agg;
+
+}
+
 sub retrieve_todo {
     my ( $self, @args ) = @_;
 
@@ -96,7 +122,6 @@ sub retrieve_todo {
     }
     return \@reports_todo;
 }
-
 
 sub delete_report {
     my $self = shift;


### PR DESCRIPTION
Intent is to lower the memory usage when generating a large volume of reports by building them one at a time rather than up front.