### PR TITLE
no error when report has missing SPF scope

### DIFF
--- a/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/SPF.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/SPF.pm
@@ -64,7 +64,10 @@ sub is_valid {
 
     foreach my $f (qw/ domain result scope /) {
         next if $self->{$f};
-        warn "SPF $f is required but missing!\n";
+        if ($f ne 'scope') {
+            # quite a few DMARC reporters don't include scope
+            warn "SPF $f is required but missing!\n";
+        }
         return 0;
     }
 


### PR DESCRIPTION
- spf: do not warn on missing SPF scope, frequently missing from incoming reports, whining to receiver accomplishes nothing
- Receive: permit other MIME types that have xml.gz filename, fixes #146
- comment indenting, so code folding works better in editors

The alternate MIME type processing _may_ have security implications.