### PR TITLE
155 delete reports

### DIFF
--- a/bin/dmarc_send_reports
+++ b/bin/dmarc_send_reports
@@ -108,10 +108,10 @@ sub send_single_report {
     });
 
     my $xml = $aggregate->as_xml();
-#   warn $xml;  ## no critic (Carp)
-#   my $dom = XML::LibXML->load_xml( string => (\$xml) );
-#   eval { $xmlschema->validate( $dom ); };
-#   die "$@" if $@;
+    # warn $xml;  ## no critic (Carp)
+    # my $dom = XML::LibXML->load_xml( string => (\$xml) );
+    # eval { $xmlschema->validate( $dom ); };
+    # die "$@" if $@;
 
     my $shrunk = $report->compress(\$xml);
     my $bytes  = length Encode::encode_utf8($shrunk);

--- a/lib/Mail/DMARC/Report/Store/SQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL.pm
@@ -139,15 +139,15 @@ sub delete_report {
     my $rows = $self->query( $self->grammar->report_record_id, [$report_id] );
     my @row_ids = map { $_->{id} } @$rows;
 
-    if (@row_ids) {
+    if (scalar @row_ids) {
         foreach my $table (qw/ report_record_spf report_record_dkim report_record_reason /) {
-            eval { $self->query( $self->grammar->delete_from_where_record_in($table), \@row_ids); };
-            warn $@ if $@;
+            eval { $self->query( $self->grammar->delete_from_where_record_in($table, \@row_ids)); };
+            # warn $@ if $@;
         }
     }
     foreach my $table (qw/ report_policy_published report_record report_error /) {
-        eval { $self->query( $self->grammar->delete_from_where_report($table), [$report_id] ); };
-        warn $@ if $@;
+        eval { $self->query( $self->grammar->delete_from_where_report( $table, [$report_id] )); };
+        # warn $@ if $@;
     }
 
     # In MySQL, where FK constraints DO cascade, this is the only query needed

--- a/lib/Mail/DMARC/Report/Store/SQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL.pm
@@ -141,11 +141,13 @@ sub delete_report {
 
     if (scalar @row_ids) {
         foreach my $table (qw/ report_record_spf report_record_dkim report_record_reason /) {
+            print "deleting $table rows " . join(',', @row_ids) . "\n" if $self->verbose;
             eval { $self->query( $self->grammar->delete_from_where_record_in($table, \@row_ids)); };
             # warn $@ if $@;
         }
     }
     foreach my $table (qw/ report_policy_published report_record report_error /) {
+        print "deleting $table rows for report $report_id\n" if $self->verbose;
         eval { $self->query( $self->grammar->delete_from_where_report( $table, [$report_id] )); };
         # warn $@ if $@;
     }

--- a/lib/Mail/DMARC/Report/Store/SQL/Grammars/MySQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL/Grammars/MySQL.pm
@@ -30,8 +30,8 @@ sub report_record_id {
 }
 
 sub delete_from_where_record_in {
-    my ($self, $table, $row_ids) = @_;
-    return "DELETE FROM $table WHERE report_record_id IN ($row_ids)"
+    my ($self, $table) = @_;
+    return "DELETE FROM $table WHERE report_record_id IN (??)"
 }
 
 sub delete_from_where_report {

--- a/lib/Mail/DMARC/Report/Store/SQL/Grammars/PostgreSQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL/Grammars/PostgreSQL.pm
@@ -32,7 +32,7 @@ sub report_record_id {
 
 sub delete_from_where_record_in {
     my ($self, $table, $row_ids) = @_;
-    return "DELETE FROM \"$table\" WHERE \"report_record_id\" IN ($row_ids)"
+    return "DELETE FROM \"$table\" WHERE \"report_record_id\" IN (??)"
 }
 
 sub delete_from_where_report {

--- a/lib/Mail/DMARC/Report/Store/SQL/Grammars/SQLite.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL/Grammars/SQLite.pm
@@ -30,8 +30,8 @@ sub report_record_id {
 }
 
 sub delete_from_where_record_in {
-    my ($self, $table, $row_ids) = @_;
-    return "DELETE FROM $table WHERE report_record_id IN ($row_ids)"
+    my ($self, $table) = @_;
+    return "DELETE FROM $table WHERE report_record_id IN (??)"
 }
 
 sub delete_from_where_report {

--- a/t/04.PurePerl.t
+++ b/t/04.PurePerl.t
@@ -152,9 +152,7 @@ sub test_external_report {
 
         # warn "path: " . $uri->path;
         ok( $uri, "new URI" );
-        ok( $dmarc->external_report($uri),
-            "external_report, $uri for $dom.com"
-        );
+        ok( $dmarc->external_report($uri), "external_report, $uri for $dom.com" );
     }
 }
 

--- a/t/12.Report.Store.SQL.t
+++ b/t/12.Report.Store.SQL.t
@@ -550,12 +550,12 @@ sub test_query_delete {
 
     my $victims = $sql->query($sql->grammar->select_from( [ 'id' ], 'report' ).$sql->grammar->limit(1));
     foreach my $v (@$victims) {
-        print "test_query_delete victim: $v->{id}\n";
+        # print "test_query_delete victim: $v->{id}\n";
         eval {
             my $r = $sql->delete_report($v->{id});
             ok( $r, "query_delete $v->{id}" );
         };
-        print $@ if ($@);
+        warn $@ if ($@);
     }
 
     # neg

--- a/t/12.Report.Store.SQL.t
+++ b/t/12.Report.Store.SQL.t
@@ -148,8 +148,21 @@ sub test_cleanup {
                 report_record, report_record_dkim, report_record_reason,
                 report_record_spf RESTART IDENTITY;'
         ), 'truncate_testing_pg_database' );
+        return;
     }
-    elsif ($provider eq 'SQLite') {
+
+    my $reports = $sql->get_report()->{rows};
+    foreach my $report (@$reports) {
+        # print Dumper($report);
+        $sql->delete_report($report->{rid});
+    }
+    $reports = $sql->get_report()->{rows};
+    if (scalar @$reports) {
+        # print Dumper($reports);
+        die "failed to delete reports!\n";
+    }
+
+    if ($provider eq 'SQLite') {
         unlink "t/reports-test.sqlite";
     }
 }
@@ -466,10 +479,8 @@ sub test_query_insert {
         [ $from_did, $begin, $end, $author_id ]
     );
     ok( $rid, "query_insert, report, $rid" );
-    ok( $sql->query(
-        $sql->grammar->delete_from('report').$sql->grammar->and_arg('id'),
-        [$rid]
-    ), "query_delete, report, $rid" );
+
+    ok( $sql->delete_report($rid), "delete_report, report, $rid");
 
     # negative tests
     eval {
@@ -493,7 +504,6 @@ sub test_query_insert {
 sub test_query_replace {
     my $end   = time + 86400;
 
-    
     my $snafus = $sql->query(
         $sql->grammar->select_from( [ 'id' ], 'report' ).$sql->grammar->and_arg('begin'),
         [ $begin ]
@@ -521,14 +531,14 @@ sub test_query_replace {
 sub test_query_update {
     my $victims = $sql->query($sql->grammar->select_from( [ 'id' ], 'report' ).$sql->grammar->limit);
     foreach my $v (@$victims) {
-        my $r = $sql->query( 
+        my $r = $sql->query(
             $sql->grammar->update( 'report', [ 'end' ] ).$sql->grammar->and_arg( 'id' ),
             [ time, $v->{id} ] );
         ok( $r, "query_update, $r" );
 
         # negative test
         eval {
-            $sql->query( 
+            $sql->query(
                 $sql->grammar->update( 'report', [ 'ed' ] ).$sql->grammar->and_arg( 'id' ),
                 [ time, $v->{id} ] );
         };
@@ -537,14 +547,15 @@ sub test_query_update {
 }
 
 sub test_query_delete {
-    
+
     my $victims = $sql->query($sql->grammar->select_from( [ 'id' ], 'report' ).$sql->grammar->limit(1));
     foreach my $v (@$victims) {
-        my $r = $sql->query(
-            $sql->grammar->delete_from( 'report' ).$sql->grammar->and_arg( 'id' ),
-            [ $v ]
-        );
-        ok( $r, "query_delete" );
+        print "test_query_delete victim: $v->{id}\n";
+        eval {
+            my $r = $sql->delete_report($v->{id});
+            ok( $r, "query_delete $v->{id}" );
+        };
+        print $@ if ($@);
     }
 
     # neg


### PR DESCRIPTION
- fix $sql->delete_report, fixes #155 
- delete_from_where_record_in, accepts single ID or list of ids
- add test that checks to assure deleted reports truly are