### PR TITLE
skip tests when not-required deps are missing

### DIFF
--- a/.release/do.sh
+++ b/.release/do.sh
@@ -7,5 +7,6 @@ assure_changes_has_entry || exit
 .release/copyright_year.sh
 .release/bump_version.sh
 .release/readme.sh
+.release/update-psl.sh
 .release/tag.sh
 .release/publish-to-cpan.sh

--- a/.release/tag.sh
+++ b/.release/tag.sh
@@ -12,7 +12,7 @@ git push --tags
 
 # create a GitHub release
 # https://developer.github.com/v3/repos/releases/#create-a-release
-echo "hint: your OTP password"
+echo "hint: your GitHub OTP password"
 
 curl -u msimerson -X POST https://api.github.com/repos/msimerson/mail-dmarc/releases -H 'Content-Type: application/json' -d "{
   \"tag_name\": \"$TAGNAME\",

--- a/.release/update-psl.sh
+++ b/.release/update-psl.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+assure_repo_is_clean || exit
+
+curl -o share/public_suffix_list https://publicsuffix.org/list/effective_tld_names.dat
+
+if ! repo_is_clean; then
+    git add share/public_suffix_list
+    git commit -m "PSL: updated"
+fi

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,10 @@
+
+### 1.20200114
+
+- skip HTTP tests when optional deps not installed #171
+- update PSL
+- auto update PSL as part of release
+
 ### 1.20200113
 
 - lazy load Net::SMTPS #168
@@ -14,13 +21,11 @@
 - sqlite: add default current_timestamp
 - bin/install_deps.pl: apt improvements
 
-
 ### 1.20191004
 
 - updated PSL
 - update jQuery, jQuery grid
 - empty ENV FROM when missing #144
-
 
 ### 1.20190831
 

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -15,7 +15,6 @@ To make changes or submit patches, visit the GitHub URL and click the ***Fork***
 Use git in the normal way:
 
     cd mail-dmarc
-    
     .... make a change or two ...
     git status       ( see changes )
     git diff         ( show diffs  )
@@ -50,10 +49,8 @@ Visit your fork on the GitHub web site. On the main page of your fork is a ***Pu
 
 Travis automatically runs build tests when commits are pushed to GitHub, and sends notifications to the author(s) in case of failure. For everyone else, checking the build status after a push request is merged is a good idea.
 
-# Releases
-
-Before a release, update the PSL:
+# Release
 
 ````sh
-curl -o share/public_suffix_list https://publicsuffix.org/list/effective_tld_names.dat
+.release/do.sh
 ````

--- a/bin/dmarc_send_reports
+++ b/bin/dmarc_send_reports
@@ -146,6 +146,7 @@ sub send_single_report {
     my $cc_sent = 0;
     my @too_big;
     URI:
+
     foreach my $u_ref (@$uri_ref) {
         my $method = $u_ref->{uri};
         my $max    = $u_ref->{max_bytes};
@@ -170,20 +171,16 @@ sub send_single_report {
             email( $to, $shrunk, \$aggregate ) and $sent++;
         }
         if ( 'http:' eq substr( $method, 0, 5 ) ) {
-            #$report->sendit->http->post( $method, \$aggregate, $shrunk ) and $sent++;
-            $report->sendit->http->post( $method, \$aggregate, $shrunk );
-            # http sending not yet enabled in module, skip this send and
-            # increment sent to avoid looping
-            $sent++;
+            $report->sendit->http->post( $method, \$aggregate, $shrunk ) and $sent++;
         }
     }
 
     if ( $sent ) {
         $report->store->delete_report($aggregate->metadata->report_id);
     }
-    else {
+    if ( !$sent && scalar @too_big ) {
         send_too_big_email(\@too_big, $bytes, $aggregate);
-    };
+    }
 
     alarm(0);
     return;
@@ -206,7 +203,7 @@ sub send_too_big_email {
         email( $to, $body );
     };
     return;
-};
+}
 
 sub get_smtp_connection {
     my ($to, $shrunk, $agg_ref) = @_;
@@ -267,7 +264,7 @@ sub get_smtp_connection {
     };
 
     return $smtp;
-};
+}
 
 sub email {
     my ($to, $shrunk, $agg_ref) = @_;

--- a/lib/Mail/DMARC/Report/Send/HTTP.pm
+++ b/lib/Mail/DMARC/Report/Send/HTTP.pm
@@ -8,7 +8,7 @@ use Carp;
 
 #use Data::Dumper;
 #use HTTP::Tiny;     # a possibility
-use Net::HTTP;
+#use Net::HTTP;      # lazy loaded in 'post'
 
 use parent 'Mail::DMARC::Base';
 
@@ -18,8 +18,10 @@ sub post {
     carp "http send feature not complete!";
     return;
 
-    # TODO: test
 ## no critic (Unreachable)
+    # TODO: test against real HTTP server, validate HTTP response
+    eval "require Net::HTTP" or return;
+
     my $ver = $Mail::DMARC::Base::VERSION;
     my $s = Net::HTTP->new( Host => $uri->host ) or croak $@;
     $s->write_request(

--- a/share/public_suffix_list
+++ b/share/public_suffix_list
@@ -241,7 +241,7 @@ wa.au
 // 3LDs
 act.edu.au
 catholic.edu.au
-eq.edu.au
+// eq.edu.au - Removed at the request of the Queensland Department of Education
 nsw.edu.au
 nt.edu.au
 qld.edu.au
@@ -1368,7 +1368,7 @@ it
 gov.it
 edu.it
 // Reserved geo-names (regions and provinces):
-// http://www.nic.it/sites/default/files/docs/Regulation_assignation_v7.1.pdf
+// https://www.nic.it/sites/default/files/archivio/docs/Regulation_assignation_v7.1.pdf
 // Regions
 abr.it
 abruzzo.it
@@ -5886,14 +5886,9 @@ gov.rs
 in.rs
 org.rs
 
-// ru : https://cctld.ru/en/domains/domens_ru/reserved/
+// ru : https://cctld.ru/files/pdf/docs/en/rules_ru-rf.pdf
+// Submitted by George Georgievsky <gug@cctld.ru>
 ru
-ac.ru
-edu.ru
-gov.ru
-int.ru
-mil.ru
-test.ru
 
 // rw : https://www.ricta.org.rw/sites/default/files/resources/registry_registrar_contract_0.pdf
 rw
@@ -6958,7 +6953,8 @@ yt
 ак.срб
 
 // xn--p1ai ("rf", Russian-Cyrillic) : RU
-// http://www.cctld.ru/en/docs/rulesrf.php
+// https://cctld.ru/files/pdf/docs/en/rules_ru-rf.pdf
+// Submitted by George Georgievsky <gug@cctld.ru>
 рф
 
 // xn--wgbl6a ("Qatar", Arabic) : QA
@@ -7078,7 +7074,7 @@ org.zw
 
 // newGTLDs
 
-// List of new gTLDs imported from https://www.icann.org/resources/registries/gtlds/v2/gtlds.json on 2019-10-13T16:52:09Z
+// List of new gTLDs imported from https://www.icann.org/resources/registries/gtlds/v2/gtlds.json on 2020-01-06T17:33:31Z
 // This list is auto-generated, don't edit it manually.
 // aaa : 2015-02-26 American Automobile Association, Inc.
 aaa
@@ -7200,6 +7196,9 @@ alsace
 // alstom : 2015-07-30 ALSTOM
 alstom
 
+// amazon : 2019-12-19 Amazon EU S.à r.l.
+amazon
+
 // americanexpress : 2015-07-31 American Express Travel Related Services Company, Inc.
 americanexpress
 
@@ -7299,7 +7298,7 @@ auto
 // autos : 2014-01-09 DERAutos, LLC
 autos
 
-// avianca : 2015-01-08 Aerovias del Continente Americano S.A. Avianca
+// avianca : 2015-01-08 Avianca Holdings S.A.
 avianca
 
 // aws : 2015-06-25 Amazon Registry Services, Inc.
@@ -7590,9 +7589,6 @@ careers
 // cars : 2014-11-13 Cars Registry Limited
 cars
 
-// cartier : 2014-06-23 Richemont DNS Inc.
-cartier
-
 // casa : 2013-11-21 Minds + Machines Group Limited
 casa
 
@@ -7670,9 +7666,6 @@ christmas
 
 // chrome : 2014-07-24 Charleston Road Registry Inc.
 chrome
-
-// chrysler : 2015-07-30 FCA US LLC.
-chrysler
 
 // church : 2014-02-06 Binky Moon, LLC
 church
@@ -7953,9 +7946,6 @@ docs
 // doctor : 2016-06-02 Binky Moon, LLC
 doctor
 
-// dodge : 2015-07-30 FCA US LLC.
-dodge
-
 // dog : 2014-12-04 Binky Moon, LLC
 dog
 
@@ -8060,9 +8050,6 @@ eus
 
 // events : 2013-12-05 Binky Moon, LLC
 events
-
-// everbank : 2014-05-15 EverBank
-everbank
 
 // exchange : 2014-03-06 Binky Moon, LLC
 exchange
@@ -8337,7 +8324,7 @@ gmail
 // gmbh : 2016-01-29 Binky Moon, LLC
 gmbh
 
-// gmo : 2014-01-09 GMO Internet Pte. Ltd.
+// gmo : 2014-01-09 GMO Internet, Inc.
 gmo
 
 // gmx : 2014-04-24 1&1 Mail & Media GmbH
@@ -8748,9 +8735,6 @@ kyoto
 // lacaixa : 2014-01-09 Fundación Bancaria Caixa d’Estalvis i Pensions de Barcelona, “la Caixa”
 lacaixa
 
-// ladbrokes : 2015-08-06 LADBROKES INTERNATIONAL PLC
-ladbrokes
-
 // lamborghini : 2015-06-04 Automobili Lamborghini S.p.A.
 lamborghini
 
@@ -8762,9 +8746,6 @@ lancaster
 
 // lancia : 2015-07-31 Fiat Chrysler Automobiles N.V.
 lancia
-
-// lancome : 2015-07-23 L'Oréal
-lancome
 
 // land : 2013-09-10 Binky Moon, LLC
 land
@@ -8816,9 +8797,6 @@ lexus
 
 // lgbt : 2014-05-08 Afilias Limited
 lgbt
-
-// liaison : 2014-10-02 Liaison Technologies, Incorporated
-liaison
 
 // lidl : 2014-09-18 Schwarz Domains und Services GmbH & Co. KG
 lidl
@@ -9063,9 +9041,6 @@ money
 // monster : 2015-09-11 XYZ.COM LLC
 monster
 
-// mopar : 2015-07-30 FCA US LLC.
-mopar
-
 // mormon : 2013-12-05 IRI Domain Management, LLC ("Applicant")
 mormon
 
@@ -9086,9 +9061,6 @@ mov
 
 // movie : 2015-02-05 Binky Moon, LLC
 movie
-
-// movistar : 2014-10-16 Telefónica S.A.
-movistar
 
 // msd : 2015-07-23 MSD Registry Holdings, Inc.
 msd
@@ -9348,9 +9320,6 @@ photos
 // physio : 2014-05-01 PhysBiz Pty Ltd
 physio
 
-// piaget : 2014-10-16 Richemont DNS Inc.
-piaget
-
 // pics : 2013-11-14 Uniregistry, Corp.
 pics
 
@@ -9462,7 +9431,7 @@ qpon
 // quebec : 2013-12-19 PointQuébec Inc
 quebec
 
-// quest : 2015-03-26 Quest ION Limited
+// quest : 2015-03-26 XYZ.COM LLC
 quest
 
 // qvc : 2015-07-30 QVC, Inc.
@@ -9861,9 +9830,6 @@ spreadbetting
 // srl : 2015-05-07 InterNetX, Corp
 srl
 
-// srt : 2015-07-30 FCA US LLC.
-srt
-
 // stada : 2014-11-13 STADA Arzneimittel AG
 stada
 
@@ -9989,9 +9955,6 @@ tech
 
 // technology : 2013-09-13 Binky Moon, LLC
 technology
-
-// telefonica : 2014-10-16 Telefónica S.A.
-telefonica
 
 // temasek : 2014-08-07 Temasek Holdings (Private) Limited
 temasek
@@ -10125,9 +10088,6 @@ ubank
 // ubs : 2014-12-11 UBS AG
 ubs
 
-// uconnect : 2015-07-30 FCA US LLC.
-uconnect
-
 // unicom : 2015-10-15 China United Network Communications Corporation Limited
 unicom
 
@@ -10248,9 +10208,6 @@ wang
 // wanggou : 2014-12-18 Amazon Registry Services, Inc.
 wanggou
 
-// warman : 2015-06-18 Weir Group IP Limited
-warman
-
 // watch : 2013-11-14 Binky Moon, LLC
 watch
 
@@ -10365,7 +10322,7 @@ xin
 // xn--3bst00m : 2013-09-13 Eagle Horizon Limited
 集团
 
-// xn--3ds443g : 2013-09-08 TLD REGISTRY LIMITED
+// xn--3ds443g : 2013-09-08 TLD REGISTRY LIMITED OY
 在线
 
 // xn--3oq18vl8pn36a : 2015-07-02 Volkswagen (China) Investment Co., Ltd.
@@ -10440,6 +10397,9 @@ xin
 // xn--cck2b3b : 2015-02-26 Amazon Registry Services, Inc.
 ストア
 
+// xn--cckwcxetd : 2019-12-19 Amazon EU S.à r.l.
+アマゾン
+
 // xn--cg4bki : 2013-09-27 SAMSUNG SDS CO., LTD
 삼성
 
@@ -10470,7 +10430,7 @@ xin
 // xn--fhbei : 2015-01-15 VeriSign Sarl
 كوم
 
-// xn--fiq228c5hs : 2013-09-08 TLD REGISTRY LIMITED
+// xn--fiq228c5hs : 2013-09-08 TLD REGISTRY LIMITED OY
 中文网
 
 // xn--fiq64b : 2013-10-14 CITIC Group Corporation
@@ -10508,6 +10468,9 @@ xin
 
 // xn--j1aef : 2015-01-15 VeriSign Sarl
 ком
+
+// xn--jlq480n2rg : 2019-12-19 Amazon EU S.à r.l.
+亚马逊
 
 // xn--jlq61u9w7b : 2015-01-08 Nokia Corporation
 诺基亚
@@ -10644,7 +10607,7 @@ yahoo
 // yamaxun : 2014-12-18 Amazon Registry Services, Inc.
 yamaxun
 
-// yandex : 2014-04-10 YANDEX, LLC
+// yandex : 2014-04-10 Yandex Europe B.V.
 yandex
 
 // yodobashi : 2014-11-20 YODOBASHI CAMERA CO.,LTD.
@@ -10693,6 +10656,12 @@ zuerich
 cc.ua
 inf.ua
 ltd.ua
+
+// Adobe : https://www.adobe.com/
+// Submitted by Ian Boston <boston@adobe.com>
+adobeaemcloud.com
+adobeaemcloud.net
+*.dev.adobeaemcloud.com
 
 // Agnat sp. z o.o. : https://domena.pl
 // Submitted by Przemyslaw Plewa <it-admin@domena.pl>
@@ -10811,6 +10780,10 @@ s3-website.eu-west-2.amazonaws.com
 s3-website.eu-west-3.amazonaws.com
 s3-website.us-east-2.amazonaws.com
 
+// Amsterdam Wireless: https://www.amsterdamwireless.nl/
+// Submitted by Imre Jonk <hostmaster@amsterdamwireless.nl>
+amsw.nl
+
 // Amune : https://amune.org/
 // Submitted by Team Amune <cert@amune.org>
 t3l3p0rt.net
@@ -10844,12 +10817,6 @@ sweetpepper.org
 // ASUSTOR Inc. : http://www.asustor.com
 // Submitted by Vincent Tseng <vincenttseng@asustor.com>
 myasustor.com
-
-// Automattic Inc. : https://automattic.com/
-// Submitted by Alex Concha <alex.concha@automattic.com>
-go-vip.co
-go-vip.net
-wpcomstaging.com
 
 // AVM : https://avm.de
 // Submitted by Andreas Weise <a.weise@avm.de>
@@ -11085,6 +11052,15 @@ co.no
 webhosting.be
 hosting-cluster.nl
 
+// Coordination Center for TLD RU and XN--P1AI : https://cctld.ru/en/domains/domens_ru/reserved/
+// Submitted by George Georgievsky <gug@cctld.ru>
+ac.ru
+edu.ru
+gov.ru
+int.ru
+mil.ru
+test.ru
+
 // COSIMO GmbH : http://www.cosimo.de
 // Submitted by Rene Marticke <rmarticke@cosimo.de>
 dyn.cosidns.de
@@ -11108,6 +11084,14 @@ realm.cz
 // Cupcake : https://cupcake.io/
 // Submitted by Jonathan Rudenberg <jonathan@cupcake.io>
 cupcake.is
+
+// Customer OCI - Oracle Dyn https://cloud.oracle.com/home https://dyn.com/dns/
+// Submitted by Gregory Drake <support@dyn.com>
+// Note: This is intended to also include customer-oci.com due to wildcards implicitly including the current label
+*.customer-oci.com
+*.oci.customer-oci.com
+*.ocp.customer-oci.com
+*.ocs.customer-oci.com
 
 // cyon GmbH : https://www.cyon.ch/
 // Submitted by Dominic Luechinger <dol@cyon.ch>
@@ -11140,6 +11124,14 @@ store.dk
 // Submitted by Daniil Burdakov <icqkill@gmail.com>
 *.dapps.earth
 *.bzz.dapps.earth
+
+// Dark, Inc. : https://darklang.com
+// Submitted by Paul Biggar <ops@darklang.com>
+builtwithdark.com
+
+// Datawire, Inc : https://www.datawire.io
+// Submitted by Richard Li <secalert@datawire.io>
+edgestack.me
 
 // Debian : https://www.debian.org/
 // Submitted by Peter Palfrader / Debian Sysadmin Team <dsa-publicsuffixlist@debian.org>
@@ -11514,6 +11506,10 @@ dynv6.net
 // Submitted by Vladimir Dudr <info@e4you.cz>
 e4.cz
 
+// En root‽ : https://en-root.org
+// Submitted by Emmanuel Raviart <emmanuel@raviart.com>
+en-root.fr
+
 // Enalean SAS: https://www.enalean.com
 // Submitted by Thomas Cottier <thomas.cottier@enalean.com>
 mytuleap.com
@@ -11743,6 +11739,10 @@ firebaseapp.com
 flynnhub.com
 flynnhosting.net
 
+// Frederik Braun https://frederik-braun.com
+// Submitted by Frederik Braun <fb@frederik-braun.com>
+0e.vc
+
 // Freebox : http://www.freebox.fr
 // Submitted by Romain Fliedel <rfliedel@freebox.fr>
 freebox-os.com
@@ -11776,8 +11776,9 @@ service.gov.uk
 gehirn.ne.jp
 usercontent.jp
 
-// Gentlent, Limited : https://www.gentlent.com
-// Submitted by Tom Klein <tklein@gentlent.com>
+// Gentlent, Inc. : https://www.gentlent.com
+// Submitted by Tom Klein <tom@gentlent.com>
+gentapps.com
 lab.ms
 
 // GitHub, Inc.
@@ -11822,6 +11823,7 @@ a.run.app
 web.app
 *.0emm.com
 appspot.com
+*.r.appspot.com
 blogspot.ae
 blogspot.al
 blogspot.am
@@ -11906,6 +11908,10 @@ publishproxy.com
 withgoogle.com
 withyoutube.com
 
+// Group 53, LLC : https://www.group53.com
+// Submitted by Tyler Todd <noc@nova53.net>
+awsmppl.com
+
 // Hakaran group: http://hakaran.cz
 // Submited by Arseniy Sokolov <security@hakaran.cz>
 fin.ci
@@ -11955,6 +11961,7 @@ col.ng
 firm.ng
 gen.ng
 ltd.ng
+ngo.ng
 ng.school
 sch.so
 
@@ -12074,6 +12081,10 @@ uni5.net
 // KnightPoint Systems, LLC : http://www.knightpoint.com/
 // Submitted by Roy Keene <rkeene@knightpoint.com>
 knightpoint.systems
+
+// KUROKU LTD : https://kuroku.ltd/
+// Submitted by DisposaBoy <security@oya.to>
+oya.to
 
 // .KRD : http://nic.krd/data/krd/Registration%20Policy.pdf
 co.krd
@@ -12469,6 +12480,10 @@ nom.uy
 nom.vc
 nom.vg
 
+// Observable, Inc. : https://observablehq.com
+// Submitted by Mike Bostock <dns@observablehq.com>
+static.observableusercontent.com
+
 // Octopodal Solutions, LLC. : https://ulterius.io/
 // Submitted by Andrew Sampson <andrew@ulterius.io>
 cya.gg
@@ -12488,6 +12503,10 @@ opencraft.hosting
 // Opera Software, A.S.A.
 // Submitted by Yngve Pettersen <yngve@opera.com>
 operaunite.com
+
+// Oursky Limited : https://skygear.io/
+// Submited by Skygear Developer <hello@skygear.io>
+skygearapp.com
 
 // OutSystems
 // Submitted by Duarte Santos <domain-admin@outsystemscloud.com>
@@ -12530,6 +12549,10 @@ gotpantheon.com
 // Peplink | Pepwave : http://peplink.com/
 // Submitted by Steve Leung <steveleung@peplink.com>
 mypep.link
+
+// Perspecta : https://perspecta.com/
+// Submitted by Kenneth Van Alstyne <kvanalstyne@perspecta.com>
+perspecta.cloud
 
 // Planet-Work : https://www.planet-work.com/
 // Submitted by Frédéric VANNIÈRE <f.vanniere@planet-work.com>
@@ -12593,6 +12616,11 @@ ras.ru
 // Submitted by Daniel Dent (https://www.danieldent.com/)
 qa2.com
 
+// QCX
+// Submitted by Cassandra Beelen <cassandra@beelen.one>
+qcx.io
+*.sys.qcx.io
+
 // QNAP System Inc : https://www.qnap.com
 // Submitted by Nick Chang <nickchang@qnap.com>
 dev-myqnapcloud.com
@@ -12615,6 +12643,7 @@ rackmaze.net
 
 // Rancher Labs, Inc : https://rancher.com
 // Submitted by Vincent Fiduccia <domains@rancher.com>
+*.on-k3s.io
 *.on-rancher.cloud
 *.on-rio.io
 
@@ -12667,6 +12696,10 @@ logoip.com
 // schokokeks.org GbR : https://schokokeks.org/
 // Submitted by Hanno Böck <hanno@schokokeks.org>
 schokokeks.net
+
+// Scottish Government: https://www.gov.scot
+// Submitted by Martin Ellis <martin.ellis@gov.scot>
+gov.scot
 
 // Scry Security : http://www.scrysec.com
 // Submitted by Shante Adam <shante@skyhat.io>
@@ -12928,6 +12961,10 @@ v-info.info
 // Voorloper.com: https://voorloper.com
 // Submitted by Nathan van Bakel <info@voorloper.com>
 voorloper.cloud
+
+// V.UA Domain Administrator : https://domain.v.ua/
+// Submitted by Serhii Rostilo <sergey@rostilo.kiev.ua>
+v.ua
 
 // Waffle Computer Inc., Ltd. : https://docs.waffleinfo.com
 // Submitted by Masayuki Note <masa@blade.wafflecell.com>

--- a/t/09.HTTP.t
+++ b/t/09.HTTP.t
@@ -1,7 +1,6 @@
 use strict;
 use warnings;
 
-use CGI;
 use Data::Dumper;
 use Test::More;
 
@@ -10,7 +9,7 @@ use Test::File::ShareDir
 
 use lib 'lib';
 
-foreach my $req ( 'DBD::SQLite 1.31', 'Net::Server::HTTP' ) {
+foreach my $req ( 'CGI', 'DBD::SQLite 1.31', 'Net::Server::HTTP' ) {
     eval "use $req";
     if ($@) {
         plan( skip_all => "$req not available" );

--- a/t/23.Report.Send.HTTP.t
+++ b/t/23.Report.Send.HTTP.t
@@ -6,6 +6,14 @@ use Test::More;
 
 use lib 'lib';
 
+foreach my $req ( 'Net::HTTP' ) {
+    eval "use $req";
+    if ($@) {
+        plan( skip_all => "$req not available" );
+        exit;
+    }
+};
+
 my $mod = 'Mail::DMARC::Report::Send::HTTP';
 use_ok($mod);
 my $http = $mod->new;


### PR DESCRIPTION
fixes #170 

- gracefully degrade when optional deps CGI & Net::HTTP are missing
- send_reports: only call too_big when necessary
- update PSL
- automate updating PSL with release