### PR TITLE
Fix db connection cache

### DIFF
--- a/lib/Mail/DMARC/Report/Store/SQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL.pm
@@ -520,8 +520,12 @@ sub db_connect {
     my $user = $self->config->{report_store}{user};
     my $pass = $self->config->{report_store}{pass};
 
-    if ($self->{grammar} and $self->{grammar}->dsn =~ /$dsn/i) {
-        return $self->{dbix} if $self->{dbix};    # caching
+    # cacheing
+    if ($self->{grammar} && $self->{dbix}) {
+        my $cached_grammar_type = $self->{grammar}->dsn;
+        if ( $dsn =~ /$cached_grammar_type/ ) {
+            return $self->{dbix};    # caching
+        }
     }
 
     my $needs_tables;


### PR DESCRIPTION
The DB Cache regex check appears to be backwards:

$self->{grammar}->dsn returns the type, ie 'mysql'
$dsn is the full dsn string '“dbi:mysql:database=foo;host=server.com;port=3306”'

The check as written is 'mysql' =~ '“dbi:mysql:database=foo;host=server.com;port=3306”', which is never true, and we open a new connection/login for every query.

I feel that {grammar}->dsn is misnamed as it returns a type not a dsn, but shall not fix that here.
