### PR TITLE
Require 5.10.0

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -29,6 +29,7 @@ my $module_build_args = {
     "Net::SMTPS" => 0,
   },
   "requires" => {
+    "perl" => "5.10.0",
     "Carp" => 0,
     "Config::Tiny" => 0,
     "DBD::SQLite" => "1.31",

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -48,6 +48,7 @@ my %META = (
         "Net::Server::HTTP" => 0,
       },
       "requires" => {
+        "perl" => "5.10.0",
         "CPAN" => 0,
         "Carp" => 0,
         "Config::Tiny" => 0,

--- a/lib/Mail/DMARC/Base.pm
+++ b/lib/Mail/DMARC/Base.pm
@@ -2,6 +2,7 @@ package Mail::DMARC::Base;
 our $VERSION = '1.20210220';
 use strict;
 use warnings;
+use 5.10.0;
 
 use Carp;
 use Config::Tiny;


### PR DESCRIPTION
I believe that there is a minimum of 5.10 already way down in our dependencies, so this shouldn't be an issue.

Fixes #183 