### PR TITLE
Should be TLS not SSL

### DIFF
--- a/lib/Mail/DMARC/Report/Sender.pm
+++ b/lib/Mail/DMARC/Report/Sender.pm
@@ -64,7 +64,7 @@ sub get_transports_for {
         return ($self->{smarthost}) if $self->{smarthost};
         my $transport_data = {
             host => $report->config->{smtp}->{smarthost},
-            ssl => 1,
+            ssl => 'starttls',
             port => 587,
             helo => $report->sendit->smtp->get_helo_hostname,
             timeout => 32,
@@ -85,7 +85,7 @@ sub get_transports_for {
     if ( Email::Sender::Transport::SMTP->can('hosts') ) {
         push @transports, Email::Sender::Transport::SMTP->new({
             hosts => \@smtp_hosts,
-            ssl => 1,
+            ssl => 'starttls',
             port => 25,
             helo => $report->sendit->smtp->get_helo_hostname,
             timeout => 32,
@@ -105,7 +105,7 @@ sub get_transports_for {
         foreach my $host ( @smtp_hosts ) {
             push @transports, Email::Sender::Transport::SMTP->new({
                 host => $host,
-                ssl => 1,
+                ssl => 'starttls',
                 port => 25,
                 helo => $report->sendit->smtp->get_helo_hostname,
                 timeout => 32,


### PR DESCRIPTION
Fixes #189 
We were using ssl when we should have been using tls.
It's still a bit messy with the 2 transports, I have a patch for Email::Sender::Transport::SMTP in the works which will reduce this to a single transport which will starttls if the remote side supports it.
