### PR TITLE
Force lower case for SPF domain input

### DIFF
--- a/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/SPF.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/SPF.pm
@@ -27,7 +27,7 @@ sub new {
 
 sub domain {
     return $_[0]->{domain} if 1 == scalar @_;
-    return $_[0]->{domain} =  $_[1];
+    return $_[0]->{domain} =  lc $_[1];
 }
 
 sub result {

--- a/t/04.PurePerl.t
+++ b/t/04.PurePerl.t
@@ -231,7 +231,7 @@ sub test_is_spf_aligned {
 
     ok( $dmarc->header_from('example.com'), "spf, set header_from" );
     ok( $dmarc->spf(
-            domain => 'example.com',
+            domain => 'example.COM',
             scope  => 'mfrom',
             result => 'pass'
         ),


### PR DESCRIPTION
RFC7489 demands a case-insensitive alignment check. This is partially achieved by lower-casing header_from input, but non-lowercase SPF input was still able to break alignment.