### PR TITLE
Apply no-network-tests from openSUSE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
             Net::IDN::Encode
             CGI
             XML::Validator::Schema
+            Net::DNS::Resolver::Mock
           sudo: false
 
       - run: perl Makefile.PL

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -50,6 +50,7 @@ jobs:
             XML::Validator::Schema
             Test::Exception
             Devel::Cover::Report::Coveralls
+            Net::DNS::Resolver::Mock
           sudo: false
 
       - run: perl Makefile.PL

--- a/.test/install-deps.sh
+++ b/.test/install-deps.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-DMARC_DEPS="Regexp::Common Config::Tiny File::ShareDir Net::DNS::Resolver DBD::SQLite DBD::Pg DBD::mysql Net::IP Socket6 Email::MIME Net::SMTPS XML::LibXML Email::Sender DBIx::Simple HTTP::Tiny Test::File::ShareDir Test::Output Net::IDN::Encode CGI XML::Validator::Schema"
+DMARC_DEPS="Regexp::Common Config::Tiny File::ShareDir Net::DNS::Resolver DBD::SQLite DBD::Pg DBD::mysql Net::IP Socket6 Email::MIME Net::SMTPS XML::LibXML Email::Sender DBIx::Simple HTTP::Tiny Test::File::ShareDir Test::Output Net::IDN::Encode CGI XML::Validator::Schema Net::DNS::Resolver::Mock"
 
 for _d in $DMARC_DEPS; do
     cpanm --quiet --notest "$_d" || exit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 
 language: perl
 perl:
+  - "5.38"
   - "5.28"
   - "5.22"
 # perlbrew (used by Travis to install perl versions) no longer supports these

--- a/Build.PL
+++ b/Build.PL
@@ -139,7 +139,8 @@ my $module_build_args = {
     "Test::Exception" => 0,
     "Test::File::ShareDir" => 0,
     "Test::More" => 0,
-    "Test::Output" => 0
+    "Test::Output" => 0,
+    "Net::DNS::Resolver::Mock" => 0
   },
   "develop_requires" => {
     "Test::Pod" => "1.41"

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,7 +30,8 @@ my %META = (
         "Test::Exception" => 0,
         "Test::File::ShareDir" => 0,
         "Test::More" => 0,
-        "Test::Output" => 0
+        "Test::Output" => 0,
+        "Net::DNS::Resolver::Mock" => 0
       }
     },
     "runtime" => {

--- a/lib/Mail/DMARC/HTTP.pm
+++ b/lib/Mail/DMARC/HTTP.pm
@@ -87,6 +87,7 @@ sub return_json_error {
 
 sub serve_validator {
     my $cgi  = shift || CGI->new();  # passed in $cgi for testing
+    my $resolver = shift; # passed in $resolver for testing
     my $json = JSON->new->utf8;
 
     print $cgi->header("application/json");
@@ -104,6 +105,8 @@ sub serve_validator {
 
     eval { $dmpp = Mail::DMARC::PurePerl->new( %$input ) };
     if ($@) { return return_json_error($@); }
+
+    $dmpp->set_resolver($resolver) if $resolver;
 
     eval { $res = $dmpp->validate(); };
     if ($@) { return return_json_error($@); }

--- a/t/03.Base.t
+++ b/t/03.Base.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 
 use Data::Dumper;
+use Net::DNS::Resolver::Mock;
 use Test::More;
 
 use Test::File::ShareDir
@@ -27,6 +28,9 @@ $base = $mod->new();
 eval { $base->config('t/mail-dmarc.ini'); };
 chomp $@;
 ok( !$@, "alternate config file" );
+
+my $resolver = new Net::DNS::Resolver::Mock();
+$base->set_resolver($resolver);
 
 __any_inet_to();
 __is_public_suffix();

--- a/t/06.Result.t
+++ b/t/06.Result.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 
 use Data::Dumper;
+use Net::DNS::Resolver::Mock;
 use Test::More;
 
 use Test::File::ShareDir
@@ -11,8 +12,16 @@ use lib 'lib';
 use_ok('Mail::DMARC::PurePerl');
 use_ok('Mail::DMARC::Result');
 
+my $resolver = new Net::DNS::Resolver::Mock();
+$resolver->zonefile_parse(join("\n",
+'tnpi.net.                         600 A     66.128.51.170',
+'_dmarc.tnpi.net.                  600 TXT   "v=DMARC1; p=reject; rua=mailto:dmarc-feedback@theartfarm.com; ruf=mailto:dmarc-feedback@theartfarm.com; pct=100"',
+'nodmarcrecord.blogspot.com.       600 A     142.251.37.1',
+''));
+
 my $pp     = Mail::DMARC::PurePerl->new;
 my $result = Mail::DMARC::Result->new;
+$pp->set_resolver($resolver);
 
 isa_ok( $result, 'Mail::DMARC::Result' );
 

--- a/t/09.HTTP.t
+++ b/t/09.HTTP.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 
 use Data::Dumper;
+use Net::DNS::Resolver::Mock;
 use Test::More;
 
 use Test::File::ShareDir
@@ -17,35 +18,42 @@ foreach my $req ( 'CGI', 'DBD::SQLite 1.31', 'JSON', 'Net::Server::HTTP' ) {
     }
 };
 
+my $resolver = new Net::DNS::Resolver::Mock();
+$resolver->zonefile_parse(join("\n",
+'tnpi.net.                         600 A   66.128.51.170',
+'_dmarc.tnpi.net.                  600 TXT "v=DMARC1; p=reject; rua=mailto:dmarc-feedback@theartfarm.com; ruf=mailto:dmarc-feedback@theartfarm.com; pct=100"',
+#'tnpi.net.                         600 MX  10 mail.theartfarm.com.',
+''));
+
 my $mod = 'Mail::DMARC::HTTP';
 use_ok($mod);
 my $http = $mod->new;
 isa_ok( $http, $mod );
 
 my $cgi = CGI->new();
-my $r = Mail::DMARC::HTTP::serve_validator($cgi);
+my $r = Mail::DMARC::HTTP::serve_validator($cgi, $resolver);
 ok($r eq 'missing POST data', "serve_validator, missing POST data");
 
 $cgi->param('POSTDATA', 'foo');
-$r = Mail::DMARC::HTTP::serve_validator($cgi);
+$r = Mail::DMARC::HTTP::serve_validator($cgi, $resolver);
 like($r, qr/expected/, "serve_validator, invalid JSON");
 
 $cgi->param('POSTDATA', '{"foo":"bar"}');
-$r = Mail::DMARC::HTTP::serve_validator($cgi);
+$r = Mail::DMARC::HTTP::serve_validator($cgi, $resolver);
 like($r, qr/no header_from/, "serve_validator, missing header_from");
 
 $cgi->param('POSTDATA', '{"header_from":"tnpi.net"}');
-$r = Mail::DMARC::HTTP::serve_validator($cgi);
+$r = Mail::DMARC::HTTP::serve_validator($cgi, $resolver);
 like($r, qr/"spf":""/, "serve_validator, missing SPF");
 like($r, qr/"dkim":"fail"/, "serve_validator, missing DKIM");
 
 $cgi->param('POSTDATA', '{"header_from":"tnpi.net","spf":[{"domain":"tnpi.net","scope":"mfrom","result":"pass"}]}');
-$r = Mail::DMARC::HTTP::serve_validator($cgi);
+$r = Mail::DMARC::HTTP::serve_validator($cgi, $resolver);
 like($r, qr/"spf":"pass"/, "serve_validator, pass SPF");
 like($r, qr/"dkim":"fail"/, "serve_validator, missing DKIM");
 
 $cgi->param('POSTDATA', '{"header_from":"tnpi.net","dkim":[{"domain":"tnpi.net","selector":"mar2013","result":"pass"}]}');
-$r = Mail::DMARC::HTTP::serve_validator($cgi);
+$r = Mail::DMARC::HTTP::serve_validator($cgi, $resolver);
 like($r, qr/"spf":""/, "serve_validator, missing SPF");
 like($r, qr/"dkim":"pass"/, "serve_validator, pass DKIM");
 

--- a/t/11.Report.Store.t
+++ b/t/11.Report.Store.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 
 use Data::Dumper;
+use Net::DNS::Resolver::Mock;
 use Test::More;
 
 use Test::File::ShareDir
@@ -15,8 +16,19 @@ if ($@) {
     exit;
 }
 
+my $resolver = new Net::DNS::Resolver::Mock();
+$resolver->zonefile_parse(join("\n",
+'tnpi.net.                         600 A   66.128.51.170',
+'tnpi.net.                         600 MX  10 mail.theartfarm.com.',
+'_dmarc.mail-dmarc.tnpi.net.       600 TXT "v=DMARC1; p=reject; rua=mailto:invalid@theartfarm.com; ruf=mailto:invalid@theartfarm.com; pct=90"',
+'_dmarc.tnpi.net.                  600 TXT "v=DMARC1; p=reject; rua=mailto:dmarc-feedback@theartfarm.com; ruf=mailto:dmarc-feedback@theartfarm.com; pct=100"',
+'mail-dmarc.tnpi.net.              600 TXT "test zone for Mail::DMARC perl module"',
+'mail-dmarc.tnpi.net._report._dmarc.theartfarm.com. 600 TXT "v=DMARC1; rua=mailto:invalid-test@theartfarm.com;"',
+''));
+
 use_ok('Mail::DMARC::PurePerl');
 my $dmarc = Mail::DMARC::PurePerl->new();
+$dmarc->set_resolver($resolver);
 isa_ok( $dmarc, 'Mail::DMARC::PurePerl' );
 
 isa_ok( $dmarc->report,        'Mail::DMARC::Report' );

--- a/t/22.Report.Send.SMTP.t
+++ b/t/22.Report.Send.SMTP.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 
 use Data::Dumper;
+use Net::DNS::Resolver::Mock;
 use Test::More;
 
 use IO::Compress::Gzip;
@@ -11,9 +12,15 @@ use Mail::DMARC::Policy;
 use Mail::DMARC::Report::Aggregate;
 use Mail::DMARC::Report::Aggregate::Record;
 
+my $resolver = new Net::DNS::Resolver::Mock();
+$resolver->zonefile_parse(join("\n",
+'tnpi.net.               600 MX  10 mail.theartfarm.com.',
+''));
+
 my $mod = 'Mail::DMARC::Report::Send::SMTP';
 use_ok($mod);
 my $smtp = $mod->new;
+$smtp->set_resolver($resolver);
 isa_ok( $smtp, $mod );
 $smtp->config('t/mail-dmarc.ini');
 


### PR DESCRIPTION
Slight refactoring of the tests from openSUSE which fix test failures when no network is present by mocking DNS responses from a local copy.

https://build.opensuse.org/package/show/devel:languages:perl/perl-Mail-DMARC