### PR TITLE
add configurable DNS retrans option

### DIFF
--- a/lib/Mail/DMARC/Base.pm
+++ b/lib/Mail/DMARC/Base.pm
@@ -250,10 +250,12 @@ sub epoch_to_iso {
 sub get_resolver {
     my $self = shift;
     my $timeout = shift || $self->config->{dns}{timeout} || 5;
+    my $retrans = shift || $self->config->{dns}{retrans} || 5;
     return $self->{resolver} if defined $self->{resolver};
     $self->{resolver} = Net::DNS::Resolver->new( dnsrch => 0 );
     $self->{resolver}->tcp_timeout($timeout);
     $self->{resolver}->udp_timeout($timeout);
+    $self->{resolver}->retrans($retrans);
     return $self->{resolver};
 }
 

--- a/share/mail-dmarc.ini
+++ b/share/mail-dmarc.ini
@@ -43,6 +43,7 @@ backend        = perl
 
 [dns]
 timeout            = 5
+retrans            = 5
 public_suffix_list = share/public_suffix_list
 
 [smtp]


### PR DESCRIPTION
Make DNS retrans option configurable in mail-dmarc.ini.
It's useful with some bad configured dns servers.