### PR TITLE
Reports: Fix the email sent when reports are too large

### DIFF
--- a/lib/Mail/DMARC/Report/Sender.pm
+++ b/lib/Mail/DMARC/Report/Sender.pm
@@ -324,7 +324,9 @@ sub send_report {
         $report->store->delete_report($aggregate->metadata->report_id);
     }
     else {
-        $self->send_too_big_email(\@too_big, $xml_compressed_bytes, $aggregate);
+        my $send_errors = $report->config->{smtp}->{send_errors} // 1;
+        $self->send_too_big_email(\@too_big, $xml_compressed_bytes, $aggregate) if $send_errors;
+        $report->store->delete_report($aggregate->metadata->report_id);
     };
 
     alarm(0);
@@ -346,7 +348,7 @@ sub send_too_big_email {
                 report_domain=> $aggregate->policy_published->domain,
             }
         );
-        my $mime_object = $report->sendit->smtp->assemble_too_big_message_object($aggregate, $to, $body);
+        my $mime_object = $report->sendit->smtp->assemble_too_big_message_object($to, $body);
         $self->email({ to => $to, mime => $mime_object });
     };
     return;

--- a/share/mail-dmarc.ini
+++ b/share/mail-dmarc.ini
@@ -61,6 +61,11 @@ smarthost =
 smartuser =
 smartpass =
 
+; Send error report emails, if set, we will send a simple report to
+; any report handler when we were unable to send an aggregate report
+; This currently covers errors where the report was too large to send.
+send_errors = 1
+
 [imap]
 server    = mail.example.com
 port      = 993


### PR DESCRIPTION
The too large error email was malformed, and the associated report was not being deleted after the send, resulting in multiple reports being sent.

1) Fix the format of the report.

2) Delete the report after any attempt to send the error email.

3) Add a new config item to disable sending any error emails at all.