### PR TITLE
imap: only use port 143 if requested

### DIFF
--- a/lib/Mail/DMARC/Report/Receive.pm
+++ b/lib/Mail/DMARC/Report/Receive.pm
@@ -27,11 +27,18 @@ sub from_imap {
     my $folder = $self->config->{imap}{folder} or croak "no imap folder conf";
     my $a_done = $self->config->{imap}{a_done};
     my $f_done = $self->config->{imap}{f_done};
-    my $port   = $self->config->{imap}{port} // $self->get_imap_port();
+    my $port   = $self->config->{imap}{port} // 993;
+
+    if (defined $self->config->{imap}{SSL_verify_mode}) {
+        IO::Socket::SSL::set_ctx_defaults(
+            SSL_verifycn_scheme => 'imap',
+            SSL_verify_mode => $self->config->{imap}{SSL_verify_mode},
+        );
+    }
 
     no warnings qw(once);                ## no critic (Warn)
     my $imap = Net::IMAP::Simple->new( $server, port => $port,
-           ($port != 143) ? (use_ssl => 1) : ()
+           use_ssl => $port != 143,
         )
         or do {
             ## no critic (PackageVar)
@@ -181,33 +188,6 @@ sub from_email_simple {
         warn "Unknown message part $c_type\n";  ## no critic (Carp)
     }
     return $rep_type;
-}
-
-sub get_imap_port {
-    my $self = shift;
-
-    eval "use IO::Socket::SSL";  ## no critic (Eval)
-    if ( $@ ) {
-        carp "no SSL, using insecure connection: $!\n";
-        return 143;
-    };
-
-    eval "use Mozilla::CA";    ## no critic (Eval)
-    if ( ! $@ ) {
-        IO::Socket::SSL::set_ctx_defaults(
-                SSL_verifycn_scheme => 'imap',
-                SSL_verify_mode => 0x02,
-                SSL_ca_file => Mozilla::CA::SSL_ca_file(),
-                );
-        return 993;
-    };
-
-    # no CA, disable verification
-    IO::Socket::SSL::set_ctx_defaults(
-        SSL_verifycn_scheme => 'imap',
-        SSL_verify_mode => 0,
-    );
-    return 993;
 }
 
 sub get_submitter_from_filename {

--- a/share/mail-dmarc.ini
+++ b/share/mail-dmarc.ini
@@ -71,6 +71,10 @@ server    = mail.example.com
 port      = 993
 user      =
 pass      =
+
+; SSL_verify_mode = 0
+; setting to 0 disables TLS certificate validation
+
 ; the imap folder where new dmarc messages will be found
 folder    = dmarc
 ; the folders to store processed reports (a=aggregate, f=forensic)


### PR DESCRIPTION
imap: add SSL_verify_mode config setting to disable TLS host validation