### PR TITLE
permit storage of UTF-8 chars in MySQL DB

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,5 @@
+- Permit storage of UTF-8 chars in MySQL DB, related to #190
+
 ### 1.20240313
 
 - Fix error email sent when reports are too large

--- a/lib/Mail/DMARC/Report/Store/SQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL.pm
@@ -531,6 +531,8 @@ sub db_connect {
     my $needs_tables;
 
     $self->{grammar} = undef;
+    my %opts;
+
     if ($dsn =~ /sqlite/i) {
         my ($db) = ( split /=/, $dsn )[-1];
         if ( !$db || $db eq ':memory:' || !-e $db ) {
@@ -541,6 +543,7 @@ sub db_connect {
         }
         $self->{grammar} = Mail::DMARC::Report::Store::SQL::Grammars::SQLite->new();
     } elsif ($dsn =~ /mysql/i) {
+        $opts{'mysql_enable_utf8mb4'} = 1;
         $self->{grammar} = Mail::DMARC::Report::Store::SQL::Grammars::MySQL->new();
     } elsif ($dsn =~ /pg/i) {
         $self->{grammar} = Mail::DMARC::Report::Store::SQL::Grammars::PostgreSQL->new();
@@ -548,7 +551,7 @@ sub db_connect {
         croak "can't determine database type, so unable to load grammar.\n";
     }
 
-    $self->{dbix} = DBIx::Simple->connect( $dsn, $user, $pass )
+    $self->{dbix} = DBIx::Simple->connect( $dsn, $user, $pass, \%opts )
         or return $self->error( DBIx::Simple->error );
 
     if ($needs_tables) {


### PR DESCRIPTION
Due to missing a character on the command line, I accidentally pushed [the commit that goes with this](https://github.com/msimerson/mail-dmarc/commit/6a830d0392987fc2fce47380fb30540bd13d0327) to `master`. Please refer to the changes there and make comments/suggestions here.