### PR TITLE
match from and envelope-from domains

### DIFF
--- a/lib/Mail/DMARC/PurePerl.pm
+++ b/lib/Mail/DMARC/PurePerl.pm
@@ -266,7 +266,7 @@ sub is_spf_aligned {
 
     my $from_dom = $self->header_from or croak "header_from not set!";
 
-    if ( $spf_dom eq $from_dom ) {
+    if ( lc($spf_dom) eq lc($from_dom) ) {
         $self->result->spf('pass');
         $self->result->spf_align('strict');
         return 1;

--- a/lib/Mail/DMARC/PurePerl.pm
+++ b/lib/Mail/DMARC/PurePerl.pm
@@ -264,7 +264,8 @@ sub is_spf_aligned {
     $self->result->spf('fail');
     return 0 if !$spf_dom;
 
-    my $from_dom = $self->header_from or croak "header_from not set!";
+    my $from_dom = lc $self->header_from or croak "header_from not set!";
+    $spf_dom = lc $spf_dom;
 
     if ( lc($spf_dom) eq lc($from_dom) ) {
         $self->result->spf('pass');

--- a/lib/Mail/DMARC/PurePerl.pm
+++ b/lib/Mail/DMARC/PurePerl.pm
@@ -267,7 +267,7 @@ sub is_spf_aligned {
     my $from_dom = lc $self->header_from or croak "header_from not set!";
     $spf_dom = lc $spf_dom;
 
-    if ( lc($spf_dom) eq lc($from_dom) ) {
+    if ( $spf_dom eq $from_dom ) {
         $self->result->spf('pass');
         $self->result->spf_align('strict');
         return 1;


### PR DESCRIPTION
 match from and envelope-from domains even if they are written in different way (camelcase or uppercase)
 Actually I cannot see if case matching is required or not in https://www.rfc-editor.org/rfc/rfc7489#section-3.1.2