### PR TITLE
silence a warning

### DIFF
--- a/t/30.Validate.t
+++ b/t/30.Validate.t
@@ -273,7 +273,7 @@ subtest 'External Reporting Verification' => sub {
     );
 
     # We need to mock get_resolver->send for verify_external_reporting
-    no warnings 'redefine';
+    no warnings qw(redefine once);
     my $old_send = Net::DNS::Resolver->can('send');
     *Net::DNS::Resolver::send = sub {
         my ($self, $name, $type) = @_;


### PR DESCRIPTION
Silence a warning in a test, Perl thinks it's a typo but it's intentional