### PR TITLE
add etc/mail to search path, warn when ini not found

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         perl-version:
-          - "5.34"
+          - "5.40"
 
     container:
       image: perl:${{ matrix.perl-version }}

--- a/.github/workflows/critic.yml
+++ b/.github/workflows/critic.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         perl-version:
-          - "5.36"
+          - "5.42"
 
     container:
       image: perl:${{ matrix.perl-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Unreleased
 
+### 2.20260724
+
+- add <prefix>/etc/mail to search path
+- warn when mail-dmarc.ini not found
+- chore: bump minimum supported Perl to 5.40.2
+
 ### 2.20260621
 
 - doc(README): updated RFCs and fixed CPAN links #305

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -49,7 +49,7 @@ my %META = (
         "Net::Server::HTTP" => 0,
       },
       "requires" => {
-        "perl" => "5.34.3",
+        "perl" => "5.40.2",
         "CPAN" => 0,
         "Carp" => 0,
         "Config::Tiny" => 0,

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Mail::DMARC - Perl implementation of DMARC
 
 # VERSION
 
-version 2.20260621
+version 2.20260724
 
 # SYNOPSIS
 

--- a/lib/Mail/DMARC.pm
+++ b/lib/Mail/DMARC.pm
@@ -2,7 +2,7 @@ package Mail::DMARC;
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
+no warnings 'experimental::args_array_with_signatures';    ## no critic (ProhibitNoWarnings)
 
 our $VERSION = '2.20260621';
 

--- a/lib/Mail/DMARC.pm
+++ b/lib/Mail/DMARC.pm
@@ -4,7 +4,7 @@ use warnings;
 use feature 'signatures';
 no warnings 'experimental::args_array_with_signatures';    ## no critic (ProhibitNoWarnings)
 
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 
 use Carp;
 our $psl_loads = 0;
@@ -307,7 +307,7 @@ Mail::DMARC - Perl implementation of DMARC
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 SYNOPSIS
 

--- a/lib/Mail/DMARC/Base.pm
+++ b/lib/Mail/DMARC/Base.pm
@@ -2,7 +2,7 @@ package Mail::DMARC::Base;
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
+no warnings 'experimental::args_array_with_signatures';    ## no critic (ProhibitNoWarnings)
 
 our $VERSION = '2.20260621';
 

--- a/lib/Mail/DMARC/Base.pm
+++ b/lib/Mail/DMARC/Base.pm
@@ -63,17 +63,21 @@ sub get_config( $self, $file = undef ) {
     $file ||= $ENV{MAIL_DMARC_CONFIG_FILE} || $self->{config_file};
     croak                            if !$file;
     return Config::Tiny->read($file) if -r $file;    # fully qualified
-    foreach my $d ( $self->get_prefix('etc') ) {
+
+    # search <prefix>/etc and the mail/ subdir where mail daemons (and
+    # FreeBSD ports, e.g. authentication_milter) conventionally install it
+    foreach my $d ( map { ( $_, "$_/mail" ) } $self->get_prefix('etc') ) {
         next                              if !-d $d;
         next                              if !-e "$d/$file";
         croak "unreadable file: $d/$file" if !-r "$d/$file";
-        my $Config = Config::Tiny->new;
         return Config::Tiny->read("$d/$file");
     }
 
     if ( $file ne 'mail-dmarc.ini' ) {
         croak "unable to find requested config file $file\n";
     }
+
+    carp "no mail-dmarc.ini found; using bundled defaults.\n";
     return Config::Tiny->read( $self->get_sharefile('mail-dmarc.ini') );
 }
 

--- a/lib/Mail/DMARC/Base.pm
+++ b/lib/Mail/DMARC/Base.pm
@@ -4,7 +4,7 @@ use warnings;
 use feature 'signatures';
 no warnings 'experimental::args_array_with_signatures';    ## no critic (ProhibitNoWarnings)
 
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 
 use Carp;
 use Config::Tiny;
@@ -346,7 +346,7 @@ Mail::DMARC::Base - DMARC utility functions
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 METHODS
 

--- a/lib/Mail/DMARC/HTTP.pm
+++ b/lib/Mail/DMARC/HTTP.pm
@@ -3,7 +3,6 @@ our $VERSION = '2.20260621';
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
 use feature 'try';
 no warnings 'experimental::try';    ## no critic (ProhibitNoWarnings)
 

--- a/lib/Mail/DMARC/HTTP.pm
+++ b/lib/Mail/DMARC/HTTP.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::HTTP;
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -222,7 +222,7 @@ Mail::DMARC::HTTP - view stored reports via HTTP
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 SYNOPSIS
 

--- a/lib/Mail/DMARC/Policy.pm
+++ b/lib/Mail/DMARC/Policy.pm
@@ -2,7 +2,7 @@ package Mail::DMARC::Policy;
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
+no warnings 'experimental::args_array_with_signatures';    ## no critic (ProhibitNoWarnings)
 
 our $VERSION = '2.20260621';
 

--- a/lib/Mail/DMARC/Policy.pm
+++ b/lib/Mail/DMARC/Policy.pm
@@ -4,7 +4,7 @@ use warnings;
 use feature 'signatures';
 no warnings 'experimental::args_array_with_signatures';    ## no critic (ProhibitNoWarnings)
 
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 
 use Carp;
 
@@ -240,7 +240,7 @@ Mail::DMARC::Policy - a DMARC policy in object format
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 SYNOPSIS
 

--- a/lib/Mail/DMARC/PurePerl.pm
+++ b/lib/Mail/DMARC/PurePerl.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::PurePerl;
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -771,7 +771,7 @@ Mail::DMARC::PurePerl - Pure Perl implementation of DMARC
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 METHODS
 

--- a/lib/Mail/DMARC/PurePerl.pm
+++ b/lib/Mail/DMARC/PurePerl.pm
@@ -3,7 +3,6 @@ our $VERSION = '2.20260621';
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
 use feature 'try';
 no warnings 'experimental::try';    ## no critic (ProhibitNoWarnings)
 

--- a/lib/Mail/DMARC/Report.pm
+++ b/lib/Mail/DMARC/Report.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use feature 'signatures';
 
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 
 use Carp;
 use IO::Compress::Gzip;
@@ -82,7 +82,7 @@ Mail::DMARC::Report - A DMARC report interface
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 DESCRIPTION
 

--- a/lib/Mail/DMARC/Report.pm
+++ b/lib/Mail/DMARC/Report.pm
@@ -2,7 +2,6 @@ package Mail::DMARC::Report;
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
 
 our $VERSION = '2.20260621';
 

--- a/lib/Mail/DMARC/Report/Aggregate.pm
+++ b/lib/Mail/DMARC/Report/Aggregate.pm
@@ -2,7 +2,6 @@ package Mail::DMARC::Report::Aggregate;
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
 
 our $VERSION = '2.20260621';
 

--- a/lib/Mail/DMARC/Report/Aggregate.pm
+++ b/lib/Mail/DMARC/Report/Aggregate.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use feature 'signatures';
 
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 
 use Carp;
 use Data::Dumper;
@@ -196,7 +196,7 @@ Mail::DMARC::Report::Aggregate - aggregate report object
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 DESCRIPTION
 

--- a/lib/Mail/DMARC/Report/Aggregate/Metadata.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Metadata.pm
@@ -2,7 +2,7 @@ package Mail::DMARC::Report::Aggregate::Metadata;
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
+no warnings 'experimental::args_array_with_signatures';    ## no critic (ProhibitNoWarnings)
 
 our $VERSION = '2.20260621';
 

--- a/lib/Mail/DMARC/Report/Aggregate/Metadata.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Metadata.pm
@@ -4,7 +4,7 @@ use warnings;
 use feature 'signatures';
 no warnings 'experimental::args_array_with_signatures';    ## no critic (ProhibitNoWarnings)
 
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 
 use XML::LibXML;
 
@@ -98,7 +98,7 @@ Mail::DMARC::Report::Aggregate::Metadata - metadata section of aggregate report
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 AUTHORS
 

--- a/lib/Mail/DMARC/Report/Aggregate/Record.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Aggregate::Record;
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -78,7 +78,7 @@ Mail::DMARC::Report::Aggregate::Record - record section of aggregate report
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 DESCRIPTION
 

--- a/lib/Mail/DMARC/Report/Aggregate/Record.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record.pm
@@ -3,7 +3,6 @@ our $VERSION = '2.20260621';
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
 
 use Carp;
 

--- a/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Aggregate::Record::Auth_Results;
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -81,7 +81,7 @@ Mail::DMARC::Report::Aggregate::Record::Auth_Results - auth_results section of a
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 AUTHORS
 

--- a/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results.pm
@@ -3,7 +3,6 @@ our $VERSION = '2.20260621';
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
 
 use Carp;
 require Mail::DMARC::Report::Aggregate::Record::Auth_Results::SPF;

--- a/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/DKIM.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/DKIM.pm
@@ -3,7 +3,7 @@ our $VERSION = '2.20260621';
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
+no warnings 'experimental::args_array_with_signatures';    ## no critic (ProhibitNoWarnings)
 
 use Carp;
 

--- a/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/DKIM.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/DKIM.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Aggregate::Record::Auth_Results::DKIM;
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -85,7 +85,7 @@ Mail::DMARC::Report::Aggregate::Record::Auth_Results::DKIM - auth_results/dkim s
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 AUTHORS
 

--- a/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/SPF.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/SPF.pm
@@ -3,7 +3,7 @@ our $VERSION = '2.20260621';
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
+no warnings 'experimental::args_array_with_signatures';    ## no critic (ProhibitNoWarnings)
 
 use Carp;
 use parent 'Mail::DMARC::Base';

--- a/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/SPF.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/SPF.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Aggregate::Record::Auth_Results::SPF;
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -93,7 +93,7 @@ Mail::DMARC::Report::Aggregate::Record::Auth_Results::SPF - auth_results/spf sec
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 AUTHORS
 

--- a/lib/Mail/DMARC/Report/Aggregate/Record/Identifiers.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Identifiers.pm
@@ -3,7 +3,7 @@ our $VERSION = '2.20260621';
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
+no warnings 'experimental::args_array_with_signatures';    ## no critic (ProhibitNoWarnings)
 
 use Carp;
 

--- a/lib/Mail/DMARC/Report/Aggregate/Record/Identifiers.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Identifiers.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Aggregate::Record::Identifiers;
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -44,7 +44,7 @@ Mail::DMARC::Report::Aggregate::Record::Identifiers - identifiers section of a D
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 AUTHORS
 

--- a/lib/Mail/DMARC/Report/Aggregate/Record/Row.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Row.pm
@@ -3,7 +3,7 @@ our $VERSION = '2.20260621';
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
+no warnings 'experimental::args_array_with_signatures';    ## no critic (ProhibitNoWarnings)
 
 use Carp;
 require Mail::DMARC::Report::Aggregate::Record::Row::Policy_Evaluated;

--- a/lib/Mail/DMARC/Report/Aggregate/Record/Row.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Row.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Aggregate::Record::Row;
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -56,7 +56,7 @@ Mail::DMARC::Report::Aggregate::Record::Row - row section of a DMARC aggregate r
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 AUTHORS
 

--- a/lib/Mail/DMARC/Report/Aggregate/Record/Row/Policy_Evaluated.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Row/Policy_Evaluated.pm
@@ -3,7 +3,7 @@ our $VERSION = '2.20260621';
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
+no warnings 'experimental::args_array_with_signatures';    ## no critic (ProhibitNoWarnings)
 
 use Carp;
 

--- a/lib/Mail/DMARC/Report/Aggregate/Record/Row/Policy_Evaluated.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Row/Policy_Evaluated.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Aggregate::Record::Row::Policy_Evaluated;
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -57,7 +57,7 @@ Mail::DMARC::Report::Aggregate::Record::Row::Policy_Evaluated - row/policy_evalu
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 AUTHORS
 

--- a/lib/Mail/DMARC/Report/Receive.pm
+++ b/lib/Mail/DMARC/Report/Receive.pm
@@ -5,7 +5,7 @@ use feature 'signatures';
 use feature 'try';
 no warnings 'experimental::try';    ## no critic (ProhibitNoWarnings)
 
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 
 use Carp;
 use Data::Dumper;
@@ -482,7 +482,7 @@ Mail::DMARC::Report::Receive - process incoming DMARC reports
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 DESCRIPTION
 

--- a/lib/Mail/DMARC/Report/Receive.pm
+++ b/lib/Mail/DMARC/Report/Receive.pm
@@ -2,7 +2,6 @@ package Mail::DMARC::Report::Receive;
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
 use feature 'try';
 no warnings 'experimental::try';    ## no critic (ProhibitNoWarnings)
 

--- a/lib/Mail/DMARC/Report/Send.pm
+++ b/lib/Mail/DMARC/Report/Send.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use feature 'signatures';
 
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 
 use parent 'Mail::DMARC::Base';
 use Mail::DMARC::Report::Send::SMTP;
@@ -60,7 +60,7 @@ Mail::DMARC::Report::Send - report sending dispatch class
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 DESCRIPTION
 

--- a/lib/Mail/DMARC/Report/Send.pm
+++ b/lib/Mail/DMARC/Report/Send.pm
@@ -2,7 +2,6 @@ package Mail::DMARC::Report::Send;
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
 
 our $VERSION = '2.20260621';
 

--- a/lib/Mail/DMARC/Report/Send/HTTP.pm
+++ b/lib/Mail/DMARC/Report/Send/HTTP.pm
@@ -2,7 +2,6 @@ package Mail::DMARC::Report::Send::HTTP;
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
 
 our $VERSION = '2.20260621';
 

--- a/lib/Mail/DMARC/Report/Send/HTTP.pm
+++ b/lib/Mail/DMARC/Report/Send/HTTP.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use feature 'signatures';
 
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 
 use Carp;
 
@@ -53,7 +53,7 @@ Mail::DMARC::Report::Send::HTTP - utility methods to send reports by HTTP
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 12.2.2. HTTP
 

--- a/lib/Mail/DMARC/Report/Send/SMTP.pm
+++ b/lib/Mail/DMARC/Report/Send/SMTP.pm
@@ -2,7 +2,6 @@ package Mail::DMARC::Report::Send::SMTP;
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
 use feature 'try';
 no warnings 'experimental::try';    ## no critic (ProhibitNoWarnings)
 

--- a/lib/Mail/DMARC/Report/Send/SMTP.pm
+++ b/lib/Mail/DMARC/Report/Send/SMTP.pm
@@ -5,7 +5,7 @@ use feature 'signatures';
 use feature 'try';
 no warnings 'experimental::try';    ## no critic (ProhibitNoWarnings)
 
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 
 use Carp;
 use English '-no_match_vars';
@@ -218,7 +218,7 @@ Mail::DMARC::Report::Send::SMTP - utility methods for sending reports via SMTP
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head2 SUBJECT FIELD
 

--- a/lib/Mail/DMARC/Report/Sender.pm
+++ b/lib/Mail/DMARC/Report/Sender.pm
@@ -3,7 +3,6 @@ package Mail::DMARC::Report::Sender;
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
 use feature 'try';
 no warnings 'experimental::try';    ## no critic (ProhibitNoWarnings)
 

--- a/lib/Mail/DMARC/Report/Store.pm
+++ b/lib/Mail/DMARC/Report/Store.pm
@@ -3,7 +3,6 @@ our $VERSION = '2.20260621';
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
 use feature 'try';
 no warnings 'experimental::try';    ## no critic (ProhibitNoWarnings)
 

--- a/lib/Mail/DMARC/Report/Store.pm
+++ b/lib/Mail/DMARC/Report/Store.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Store;
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -60,7 +60,7 @@ Mail::DMARC::Report::Store - persistent storage broker for reports
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 SYNOPSIS
 

--- a/lib/Mail/DMARC/Report/Store/SQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL.pm
@@ -3,7 +3,6 @@ our $VERSION = '2.20260621';
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
 
 use Carp;
 use Data::Dumper;

--- a/lib/Mail/DMARC/Report/Store/SQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Store::SQL;
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -703,7 +703,7 @@ Mail::DMARC::Report::Store::SQL - store and retrieve reports from a SQL RDBMS
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 DESCRIPTION
 

--- a/lib/Mail/DMARC/Report/Store/SQL/Grammars/MySQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL/Grammars/MySQL.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Store::SQL::Grammars::MySQL;
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -291,7 +291,7 @@ Mail::DMARC::Report::Store::SQL::Grammars::MySQL - Grammar for working with mysq
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 SYPNOSIS
 

--- a/lib/Mail/DMARC/Report/Store/SQL/Grammars/MySQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL/Grammars/MySQL.pm
@@ -3,7 +3,6 @@ our $VERSION = '2.20260621';
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
 
 sub new($class) {
     my $self = {};

--- a/lib/Mail/DMARC/Report/Store/SQL/Grammars/PostgreSQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL/Grammars/PostgreSQL.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Store::SQL::Grammars::PostgreSQL;
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -313,7 +313,7 @@ Mail::DMARC::Report::Store::SQL::Grammars::PostgreSQL - Grammar for working with
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 SYPNOSIS
 

--- a/lib/Mail/DMARC/Report/Store/SQL/Grammars/PostgreSQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL/Grammars/PostgreSQL.pm
@@ -3,7 +3,6 @@ our $VERSION = '2.20260621';
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
 
 sub new($class) {
     my $self = {};

--- a/lib/Mail/DMARC/Report/Store/SQL/Grammars/SQLite.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL/Grammars/SQLite.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Store::SQL::Grammars::SQLite;
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -291,7 +291,7 @@ Mail::DMARC::Report::Store::SQL::Grammars::SQLite - Grammar for working with sql
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 SYPNOSIS
 

--- a/lib/Mail/DMARC/Report/Store/SQL/Grammars/SQLite.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL/Grammars/SQLite.pm
@@ -3,7 +3,6 @@ our $VERSION = '2.20260621';
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
 
 sub new($class) {
     my $self = {};

--- a/lib/Mail/DMARC/Report/URI.pm
+++ b/lib/Mail/DMARC/Report/URI.pm
@@ -2,7 +2,6 @@ package Mail::DMARC::Report::URI;
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
 
 our $VERSION = '2.20260621';
 

--- a/lib/Mail/DMARC/Report/URI.pm
+++ b/lib/Mail/DMARC/Report/URI.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use feature 'signatures';
 
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 
 use Carp;
 use URI;
@@ -68,7 +68,7 @@ Mail::DMARC::Report::URI - a DMARC report URI
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 SYNOPSIS
 

--- a/lib/Mail/DMARC/Result.pm
+++ b/lib/Mail/DMARC/Result.pm
@@ -3,7 +3,7 @@ our $VERSION = '2.20260621';
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
+no warnings 'experimental::args_array_with_signatures';    ## no critic (ProhibitNoWarnings)
 
 use Carp;
 require Mail::DMARC::Result::Reason;

--- a/lib/Mail/DMARC/Result.pm
+++ b/lib/Mail/DMARC/Result.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Result;
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -94,7 +94,7 @@ Mail::DMARC::Result - an aggregate report result object
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 OVERVIEW
 

--- a/lib/Mail/DMARC/Result/Reason.pm
+++ b/lib/Mail/DMARC/Result/Reason.pm
@@ -3,7 +3,7 @@ our $VERSION = '2.20260621';
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
+no warnings 'experimental::args_array_with_signatures';    ## no critic (ProhibitNoWarnings)
 
 use Carp;
 

--- a/lib/Mail/DMARC/Result/Reason.pm
+++ b/lib/Mail/DMARC/Result/Reason.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Result::Reason;
-our $VERSION = '2.20260621';
+our $VERSION = '2.20260724';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -46,7 +46,7 @@ Mail::DMARC::Result::Reason - policy override reason
 
 =head1 VERSION
 
-version 2.20260621
+version 2.20260724
 
 =head1 METHODS
 

--- a/lib/Mail/DMARC/Test/Transport.pm
+++ b/lib/Mail/DMARC/Test/Transport.pm
@@ -4,7 +4,6 @@ package Mail::DMARC::Test::Transport;
 use strict;
 use warnings;
 use feature 'signatures';
-no warnings 'experimental::signatures';    ## no critic (ProhibitNoWarnings)
 use Email::Sender::Transport::Test;
 
 sub new($class) {

--- a/share/public_suffix_list
+++ b/share/public_suffix_list
@@ -5,8 +5,8 @@
 // Please pull this list from, and only from https://publicsuffix.org/list/public_suffix_list.dat,
 // rather than any other VCS sites. Pulling from any other URL is not guaranteed to be supported.
 
-// VERSION: 2026-06-13_21-47-18_UTC
-// COMMIT: 9186eeeda85cef35b1551d00731464939c765cab
+// VERSION: 2026-07-23_18-24-27_UTC
+// COMMIT: 93b4eb174b2da9ee3f6effc363b579a96a65c93a
 
 // Instructions on pulling and using this list can be found at https://publicsuffix.org/list/.
 
@@ -1176,12 +1176,16 @@ gov.gd
 // Confirmed by registry <info@nic.ge> 2024-11-20
 ge
 com.ge
+cyb.ge
 edu.ge
 gov.ge
+llc.ge
 net.ge
+online.ge
 org.ge
 pvt.ge
 school.ge
+tnx.ge
 
 // gf : https://www.iana.org/domains/root/db/gf.html
 gf
@@ -1464,11 +1468,14 @@ tv.im
 // Please note, that nic.in is not an official eTLD, but used by most
 // government institutions.
 // Confirmed by Gaurav Kansal <gaurav.kansal@nic.in> 2025-11-06
+// Added aero.in, alumni.in, school.in and ub.in by Gaurav Kansal <gaurav.kansal@nic.in> 2026-06-25
 in
 5g.in
 6g.in
 ac.in
+aero.in
 ai.in
+alumni.in
 am.in
 bank.in
 bihar.in
@@ -1503,8 +1510,10 @@ pg.in
 post.in
 pro.in
 res.in
+school.in
 travel.in
 tv.in
+ub.in
 uk.in
 up.in
 us.in
@@ -1622,7 +1631,6 @@ trentin-sudtirol.it
 trentin-südtirol.it
 trentin-sued-tirol.it
 trentin-suedtirol.it
-trentino.it
 trentino-a-adige.it
 trentino-aadige.it
 trentino-alto-adige.it
@@ -1643,7 +1651,6 @@ trentinos-tirol.it
 trentinostirol.it
 trentinosud-tirol.it
 trentinosüd-tirol.it
-trentinosudtirol.it
 trentinosüdtirol.it
 trentinosued-tirol.it
 trentinosuedtirol.it
@@ -1659,7 +1666,6 @@ umbria.it
 val-d-aosta.it
 val-daosta.it
 vald-aosta.it
-valdaosta.it
 valle-aosta.it
 valle-d-aosta.it
 valle-daosta.it
@@ -1696,7 +1702,6 @@ aosta.it
 aoste.it
 ap.it
 aq.it
-aquila.it
 ar.it
 arezzo.it
 ascoli-piceno.it
@@ -1920,6 +1925,9 @@ sondrio.it
 sp.it
 sr.it
 ss.it
+su.it
+sud-sardegna.it
+sudsardegna.it
 südtirol.it
 suedtirol.it
 sv.it
@@ -1940,6 +1948,7 @@ trani-barletta-andria.it
 traniandriabarletta.it
 tranibarlettaandria.it
 trapani.it
+trentino.it
 trento.it
 treviso.it
 trieste.it
@@ -1958,6 +1967,7 @@ ve.it
 venezia.it
 venice.it
 verbania.it
+verbano-cusio-ossola.it
 vercelli.it
 verona.it
 vi.it
@@ -4336,14 +4346,18 @@ no
 fhs.no
 folkebibl.no
 fylkesbibl.no
+gielda.no
+herad.no
 idrett.no
+kommune.no
 museum.no
 priv.no
+suohkan.no
+tjielte.no
+uenorge.no
 vgs.no
 // Norid category second-level domains managed by parties other than Norid : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-d/
 dep.no
-herad.no
-kommune.no
 mil.no
 stat.no
 // Norid geographical second level domains : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-b/
@@ -4484,7 +4498,7 @@ askøy.no
 askvoll.no
 asnes.no
 åsnes.no
-audnedaln.no
+audnedal.no
 aukra.no
 aure.no
 aurland.no
@@ -4595,7 +4609,6 @@ forsand.no
 fosnes.no
 fræna.no
 frana.no
-frei.no
 frogn.no
 froland.no
 frosta.no
@@ -4646,6 +4659,7 @@ halden.no
 halsa.no
 hamar.no
 hamaroy.no
+hamarøy.no
 hammarfeasta.no
 hámmárfeasta.no
 hammerfest.no
@@ -4700,6 +4714,7 @@ karasjohka.no
 kárášjohka.no
 karasjok.no
 karlsoy.no
+karlsøy.no
 karmoy.no
 karmøy.no
 kautokeino.no
@@ -4888,6 +4903,7 @@ ralingen.no
 rana.no
 randaberg.no
 rauma.no
+re.no
 rendalen.no
 rennebu.no
 rennesoy.no
@@ -5045,6 +5061,7 @@ tysvær.no
 tysvar.no
 ullensaker.no
 ullensvang.no
+ulstein.no
 ulvik.no
 unjarga.no
 unjárga.no
@@ -5800,7 +5817,6 @@ or.th
 
 // tj : http://www.nic.tj/policy.html
 tj
-ac.tj
 biz.tj
 co.tj
 com.tj
@@ -6822,7 +6838,7 @@ org.zw
 
 // newGTLDs
 
-// List of new gTLDs imported from https://www.icann.org/resources/registries/gtlds/v2/gtlds.json on 2026-06-13T16:12:40Z
+// List of new gTLDs imported from https://www.icann.org/resources/registries/gtlds/v2/gtlds.json on 2026-07-15T16:20:56Z
 // This list is auto-generated, don't edit it manually.
 // aaa : American Automobile Association, Inc.
 // https://www.iana.org/domains/root/db/aaa.html
@@ -8888,7 +8904,7 @@ kred
 // https://www.iana.org/domains/root/db/kuokgroup.html
 kuokgroup
 
-// kyoto : Academic Institution: Kyoto Jyoho Gakuen
+// kyoto : Academic Institution: The University of Informatics
 // https://www.iana.org/domains/root/db/kyoto.html
 kyoto
 
@@ -12561,12 +12577,6 @@ bubbleapps.io
 // Submitted by Klara Mall <dns@bwcloud-os.de>
 *.bwcloud-os-instance.de
 
-// Bytemark Hosting : https://www.bytemark.co.uk
-// Submitted by Paul Cammish <paul.cammish@bytemark.co.uk>
-uk0.bigv.io
-dh.bytemark.co.uk
-vm.bytemark.co.uk
-
 // Caf.js Labs LLC : https://www.cafjs.com
 // Submitted by Antonio Lain <antlai@cafjs.com>
 cafjs.com
@@ -12751,6 +12761,12 @@ co.ca
 // Submitted by Gavin Brown <gavin.brown@centralnic.com>
 co.com
 
+// Code For Host Inc Ltd : https://codeforhost.com
+// Submitted by Mehedi Hasan <support@codeforhost.com>
+sch.ac
+dev.cv
+store.cv
+
 // Codeberg e. V. : https://codeberg.org
 // Submitted by Moritz Marquardt <git@momar.de>
 codeberg.page
@@ -12819,10 +12835,6 @@ craft.me
 // Craynic, s.r.o. : http://www.craynic.com/
 // Submitted by Ales Krajnik <ales.krajnik@craynic.com>
 realm.cz
-
-// Cryptonomic : https://cryptonomic.net/
-// Submitted by Andrew Cady <public-suffix-list@cryptonomic.net>
-*.cryptonomic.net
 
 // cyber_Folks S.A. : https://cyberfolks.pl
 // Submitted by Bartlomiej Kida <security@cyberfolks.pl>
@@ -12906,11 +12918,6 @@ deployagent.space
 // Submitted by Peter Thomassen <peter@desec.io>
 dedyn.io
 
-// Deta : https://www.deta.sh/
-// Submitted by Aavash Shrestha <aavash@deta.sh>
-deta.app
-deta.dev
-
 // Deuxfleurs : https://deuxfleurs.fr
 // Submitted by Aeddis Desauw <ca@deuxfleurs.fr>
 deuxfleurs.eu
@@ -12976,9 +12983,22 @@ cc.cd
 us.ci
 de5.net
 
-// DNShome : https://www.dnshome.de/
+// dnsHome : https://www.dnshome.de/
 // Submitted by Norbert Auler <mail@dnshome.de>
+dnshome.at
+resolve.bar
+ddns.berlin
+dnshome.cloud
+ddnssec.de
 dnshome.de
+dyndnssec.de
+heimdns.de
+srvdns.de
+dnshome.eu
+dnshome.it
+dyn.now
+heimdns.online
+ddns.wtf
 
 // DotArai : https://www.dotarai.com/
 // Submitted by Atsadawat Netcharadsang <atsadawat@dotarai.co.th>
@@ -13476,10 +13496,6 @@ expo.app
 on.expo.app
 staging.expo.app
 on.staging.expo.app
-
-// Fabrica Technologies, Inc. : https://www.fabrica.dev/
-// Submitted by Eric Jiang <eric@fabrica.dev>
-onfabrica.com
 
 // fachschaften.org: https://fachschaften.org/
 // Submitted by Felix Schäfer <security@fachschaften.org>
@@ -14137,10 +14153,6 @@ in-vpn.org
 // Submitted by Connor McFarlane <noc@inferno.co.uk>
 oninferno.net
 
-// info.at : http://www.info.at/
-biz.at
-info.at
-
 // info.cx : http://info.cx
 // Submitted by June Slater <whois@igloo.to>
 info.cx
@@ -14215,6 +14227,12 @@ iopsys.se
 // IPiFony Systems, Inc. : https://www.ipifony.com/
 // Submitted by Matthew Hardeman <mhardeman@ipifony.com>
 ipifony.net
+
+// IPv64.net : https://ipv64.net/
+// Submitted by Dennis Schröder <info@ipv64.net>
+home64.de
+ipv64.de
+ipv64.net
 
 // ir.md : https://nic.ir.md
 // Submitted by Ali Soizi <info@nic.ir.md>
@@ -14601,7 +14619,6 @@ polyspace.com
 // May First - People Link : https://mayfirst.org/
 // Submitted by Jamie McClelland <info@mayfirst.org>
 mayfirst.info
-mayfirst.org
 
 // McHost : https://mchost.ru
 // Submitted by Evgeniy Subbotin <e.subbotin@mchost.ru>
@@ -14720,6 +14737,10 @@ mittwald.info
 mittwaldserver.info
 typo3server.info
 project.space
+
+// MKM : https://mkm.fan/
+// Submitted by Kashi Ahmer <admin@mkm.fan>
+mkm.fan
 
 // Mocha : https://getmocha.com
 // Submitted by Ben Reinhart <security@getmocha.com>
@@ -15184,6 +15205,10 @@ us.platform.sh
 *.platformsh.site
 *.tst.site
 
+// Playcode : https://playcode.io
+// Submitted by Ruslan Ianberdin <security@playcode.io>
+playcode.site
+
 // Pley AB : https://www.pley.com/
 // Submitted by Henning Pohl <infra@pley.com>
 pley.games
@@ -15228,10 +15253,6 @@ vki.kr
 // Submitted by yumenewa <admin@project-study.com>
 dev.project-study.com
 
-// Protonet GmbH : http://protonet.io
-// Submitted by Martin Meier <admin@protonet.io>
-protonet.io
-
 // PSL Sandbox : https://github.com/groundcat/PSL-Sandbox
 // Submitted by groundcat <psl-sandbox@alumni.upenn.edu>
 platter-app.dev
@@ -15253,6 +15274,12 @@ nyc.mn
 // pubtls.org : https://www.pubtls.org
 // Submitted by Kor Nielsen <kor@pubtls.org>
 pubtls.org
+
+// Puter : https://puter.com
+// Submitted by Puter Security Team <security@puter.com>
+puter.app
+puter.site
+puter.work
 
 // PythonAnywhere LLP : https://www.pythonanywhere.com
 // Submitted by Giles Thomas <giles@pythonanywhere.com>
@@ -15406,10 +15433,6 @@ repl.run
 // Submitted by Tim Perry <tim@resin.io>
 resindevice.io
 devices.resinstaging.io
-
-// RethinkDB : https://www.rethinkdb.com/
-// Submitted by Chris Kastorff <info@rethinkdb.com>
-hzc.io
 
 // Rico Developments Limited : https://adimo.co
 // Submitted by Colin Brown <hello@adimo.co>
@@ -15612,9 +15635,10 @@ dedibox.fr
 schokokeks.net
 
 // Scottish Government : https://www.gov.scot
-// Submitted by Martin Ellis <martin.ellis@gov.scot>
+// Submitted by Martin Ellis <digital-publishing@gov.scot>
 gov.scot
 service.gov.scot
+mygov.scot
 
 // Scry Security : http://www.scrysec.com
 // Submitted by Shante Adam <shante@skyhat.io>
@@ -15832,10 +15856,6 @@ indevs.in
 musician.io
 novecore.site
 
-// Standard Library : https://stdlib.com
-// Submitted by Jacob Lee <jacob@stdlib.com>
-api.stdlib.com
-
 // statichost.eu : https://www.statichost.eu
 // Submitted by Eric Selin <admin@statichost.eu>
 statichost.page
@@ -15861,10 +15881,6 @@ ipfs.w3s.link
 // Storebase : https://www.storebase.io
 // Submitted by Tony Schirmer <tony@storebase.io>
 storebase.store
-
-// Storj Labs Inc. : https://storj.io/
-// Submitted by Philip Hutchins <hostmaster@storj.io>
-storj.farm
 
 // Strapi : https://strapi.io/
 // Submitted by Florent Baldino <security@strapi.io>
@@ -16305,6 +16321,10 @@ weeklylottery.org.uk
 // Submitted by Brandon DuRette <brandon.durette@wpengine.com>
 wpenginepowered.com
 js.wpenginepowered.com
+
+// xAI : https://x.ai/
+// Submitted by Asim Shrestha <security@x.ai>
+grok.me
 
 // XenonCloud GbR : https://xenoncloud.net
 // Submitted by Julian Uphoff <publicsuffixlist@xenoncloud.net>

--- a/t/03.Base.t
+++ b/t/03.Base.t
@@ -3,7 +3,10 @@ use warnings;
 use feature 'try';
 no warnings 'experimental::try';  ## no critic (ProhibitNoWarnings)
 
+use Cwd;
 use Data::Dumper;
+use File::Path qw(make_path);
+use File::Temp qw(tempdir);
 use Net::DNS::Resolver::Mock;
 use Test::More;
 use Test::Exception;
@@ -38,6 +41,8 @@ __is_valid_ip();
 __is_valid_domain();
 __epoch_to_iso();
 __get_prefix();
+__get_config_etc_mail();
+__get_config_fallback_warns();
 __get_sharefile();
 __psl_cached();
 __psl_cached_reload();
@@ -166,6 +171,33 @@ sub __get_prefix {
         [ '/usr/local/share', '/opt/local/share', '/share', './share' ],
         "get_prefix(share): /usr/local/share, /opt/local/share, /share, ./share",
     );
+}
+
+sub __get_config_etc_mail {
+    # mail daemons (and FreeBSD ports) install to <prefix>/etc/mail/, which
+    # get_config must search in addition to <prefix>/etc/ (github #296)
+    my $cwd = getcwd();
+    my $dir = tempdir( CLEANUP => 1 );
+    make_path("$dir/etc/mail");
+    my $dsn = 'dbi:SQLite:dbname=/var/db/dmarc/reports.sqlite';
+    open my $fh, '>', "$dir/etc/mail/mail-dmarc.ini" or die $!;
+    print {$fh} "[report_store]\ndsn = $dsn\n";
+    close $fh;
+
+    chdir $dir or die $!;
+    my $config = $mod->new->get_config('mail-dmarc.ini');
+    chdir $cwd or die $!;
+
+    is( $config->{report_store}{dsn},
+        $dsn, "get_config finds mail-dmarc.ini in etc/mail/" );
+}
+
+sub __get_config_fallback_warns {
+    my @warns;
+    local $SIG{__WARN__} = sub { push @warns, @_ };
+    $mod->new->get_config('mail-dmarc.ini');
+    ok( ( grep {/using bundled defaults/} @warns ),
+        "get_config warns when falling back to bundled defaults" );
 }
 
 sub __get_sharefile {

--- a/t/04.PurePerl.t
+++ b/t/04.PurePerl.t
@@ -532,6 +532,7 @@ sub test_validate_psd_y {
         header_from => 'sub.psd.dmarctest.net',
     ) );
     $dmarc->set_resolver($resolver);
+    $dmarc->config;    # warm cache so the one-time no-ini warning fires outside the trap
     my @warns;
     local $SIG{__WARN__} = sub { push @warns, @_ };
     $dmarc->validate();


### PR DESCRIPTION
- add <prefix>/etc/mail to search path
- warn when mail-dmarc.ini not found
- chore: bump minimum supported Perl to 5.40.2

fixes #296 
fixes #304 
fixes #306 