### PR TITLE
Release 2.20260827

### DIFF
--- a/.release/base.sh
+++ b/.release/base.sh
@@ -4,8 +4,31 @@ set -e
 
 get_version()
 {
+    # A release branch pins the version. Without this, a run started before
+    # midnight and re-run after it would target a different version, and every
+    # step would redo itself against the new date.
+    branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')
+    case "$branch" in
+        release-[0-9]*)
+            echo "${branch#release-}"
+            return 0
+            ;;
+    esac
+
     major=$(sed -n "s/.*VERSION = '\([0-9][0-9]*\)\..*/\1/p" lib/Mail/DMARC.pm | head -1)
     echo "${major}.$(date '+%Y%m%d')"
+}
+
+# the commit a tag resolves to, empty if there is no such tag. Annotated tags
+# need the ^{commit} peel; without it this returns the tag object instead.
+tag_commit()
+{
+    git rev-parse --quiet --verify "refs/tags/$1^{commit}" 2>/dev/null
+}
+
+release_exists()
+{
+    gh release view "$1" >/dev/null 2>&1
 }
 
 repo_is_clean()

--- a/.release/publish-to-cpan.sh
+++ b/.release/publish-to-cpan.sh
@@ -2,19 +2,33 @@
 
 set -e
 
+# shellcheck source=.release/base.sh
+. .release/base.sh
+
+DIST="Mail-DMARC-$(get_version).tar.gz"
+
 if [ -n "$PERL_PUBLISH_SETUP" ]; then
 	perl -MCPAN -e 'install Module::Build'
 	perl -MCPAN -e 'install Mozilla::CA'
 	perl -MCPAN -e 'install CPAN::Uploader'
 fi
 
+# an unmatched glob is the literal pattern, which rm then fails on. ./Build dist
+# also leaves a staging directory behind, so this cannot be rm without -r.
 for _f in Mail-DMARC-*;
 do
+	[ -e "$_f" ] || continue
 	echo "rm $_f"
-	rm $_f
+	rm -rf "$_f"
 done
 
 perl Build.PL
 ./Build dist
 ./Build distclean
-cpan-upload Mail-DMARC-*.tar.gz
+
+if [ ! -f "$DIST" ]; then
+	echo "ERROR: expected $DIST, found: $(echo Mail-DMARC-*)"
+	exit 1
+fi
+
+cpan-upload "$DIST"

--- a/.release/tag.sh
+++ b/.release/tag.sh
@@ -2,38 +2,52 @@
 
 set -e
 
+# shellcheck source=.release/base.sh
 . .release/base.sh
 
 assure_repo_is_clean
 
 TAG_NAME="v$(get_version)"
-echo "tag $TAG_NAME"
+# tag.gpgsign makes an unadorned 'git tag' want a message from an editor, which
+# a script has no way to answer
+TAG_MSG="release $(get_version)"
+HEAD_COMMIT=$(git rev-parse HEAD)
+TAGGED_COMMIT=$(tag_commit "$TAG_NAME" || true)
+FORCE=''
 
-git tag "$TAG_NAME"
-git push --tags
+if [ -z "$TAGGED_COMMIT" ]; then
+    echo "tag $TAG_NAME"
+    git tag -m "$TAG_MSG" "$TAG_NAME"
+elif [ "$TAGGED_COMMIT" = "$HEAD_COMMIT" ]; then
+    echo "tag $TAG_NAME is already on this commit"
+elif release_exists "$TAG_NAME"; then
+    echo "ERROR: $TAG_NAME has a release but points at $TAGGED_COMMIT, not HEAD."
+    echo "Delete that release and tag, or release a new version."
+    exit 1
+else
+    # earlier steps commit as they go, so a re-run that picks up a new PSL
+    # leaves the tag behind HEAD. Nothing refers to it yet, so move it.
+    echo "moving $TAG_NAME to $HEAD_COMMIT"
+    git tag -f -m "$TAG_MSG" "$TAG_NAME"
+    FORCE='--force'
+fi
 
-#PREV_TAG_NAME=$(gh release list --exclude-drafts --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName')
-PREV_TAG_NAME=$(gh release view --json tagName --jq .tagName)
+# a single tag, not --tags: this should not push unrelated local tags
+# shellcheck disable=SC2086
+git push $FORCE origin "refs/tags/$TAG_NAME"
 
-gh release create \
-  "$TAG_NAME" \
-  --title "$TAG_NAME" \
-  --target master \
-  --draft \
-  --generate-notes \
-  --notes-start-tag "$PREV_TAG_NAME" \
+if release_exists "$TAG_NAME"; then
+    echo "release $TAG_NAME already exists"
+    exit 0
+fi
 
-# GitHub CLI api
-# https://cli.github.com/manual/gh_api
+PREV_TAG_NAME=$(gh release list --exclude-drafts --exclude-pre-releases \
+    --limit 1 --json tagName --jq '.[0].tagName // empty')
 
-#gh api \
-#  --method POST \
-#  -H "Accept: application/vnd.github+json" \
-#  -H "X-GitHub-Api-Version: 2022-11-28" \
-#  /repos/msimerson/mail-dmarc/releases \
-# -f tag_name="$TAG_NAME" \
-# -f target_commitish='master' \
-# -f name="$TAG_NAME" \
-# -F draft=true \
-# -F prerelease=false \
-# -F generate_release_notes=true
+# no --target: the tag is already pushed, so the release takes its commit
+set -- "$TAG_NAME" --title "$TAG_NAME" --draft --generate-notes
+if [ -n "$PREV_TAG_NAME" ]; then
+    set -- "$@" --notes-start-tag "$PREV_TAG_NAME"
+fi
+
+gh release create "$@"

--- a/.release/update-psl.sh
+++ b/.release/update-psl.sh
@@ -2,13 +2,24 @@
 
 set -e
 
+# shellcheck source=.release/base.sh
 . .release/base.sh
 
 assure_repo_is_clean
 
-curl -o share/public_suffix_list https://publicsuffix.org/list/effective_tld_names.dat
+PSL=share/public_suffix_list
+
+# a half-written .new left by a failed transfer would make the next run see a
+# dirty repo and refuse to start
+trap 'rm -f "$PSL.new"' EXIT
+
+# straight to $PSL would leave a truncated list committed if the transfer died
+curl --fail --silent --show-error \
+    --output "$PSL.new" \
+    https://publicsuffix.org/list/effective_tld_names.dat
+mv "$PSL.new" "$PSL"
 
 if ! repo_is_clean; then
-    git add share/public_suffix_list
+    git add "$PSL"
     git commit -m "chore: updated PSL"
 fi

--- a/.release/version_increment.sh
+++ b/.release/version_increment.sh
@@ -21,8 +21,10 @@ update_modules()
 
 update_meta()
 {
-    # update the version in META.* files
+    # Build.PL does not touch META.*; distmeta is what rewrites them, and it
+    # needs the Build script that distclean then removes
     perl Build.PL
+    ./Build distmeta
     ./Build distclean
     git add META.*
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+### 2.20260827
+
 - feat(dmarc_httpd): post_max setting, defaults to 10MB
 - perf: lazy load the reporting stack, 40% faster startup
 - chore(deps): drop Regexp::Common, CGI

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -15,3 +15,4 @@
 ^MYMETA.
 dmarc_reports.sqlite
 t/reports-test.sqlite
+^pm_to_blib$

--- a/META.json
+++ b/META.json
@@ -78,114 +78,114 @@
    "provides" : {
       "Mail::DMARC" : {
          "file" : "lib/Mail/DMARC.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Base" : {
          "file" : "lib/Mail/DMARC/Base.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::HTTP" : {
          "file" : "lib/Mail/DMARC/HTTP.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Policy" : {
          "file" : "lib/Mail/DMARC/Policy.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::PurePerl" : {
          "file" : "lib/Mail/DMARC/PurePerl.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Report" : {
          "file" : "lib/Mail/DMARC/Report.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Report::Aggregate" : {
          "file" : "lib/Mail/DMARC/Report/Aggregate.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Report::Aggregate::Metadata" : {
          "file" : "lib/Mail/DMARC/Report/Aggregate/Metadata.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Report::Aggregate::Record" : {
          "file" : "lib/Mail/DMARC/Report/Aggregate/Record.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Report::Aggregate::Record::Auth_Results" : {
          "file" : "lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Report::Aggregate::Record::Auth_Results::DKIM" : {
          "file" : "lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/DKIM.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Report::Aggregate::Record::Auth_Results::SPF" : {
          "file" : "lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/SPF.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Report::Aggregate::Record::Identifiers" : {
          "file" : "lib/Mail/DMARC/Report/Aggregate/Record/Identifiers.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Report::Aggregate::Record::Row" : {
          "file" : "lib/Mail/DMARC/Report/Aggregate/Record/Row.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Report::Aggregate::Record::Row::Policy_Evaluated" : {
          "file" : "lib/Mail/DMARC/Report/Aggregate/Record/Row/Policy_Evaluated.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Report::Receive" : {
          "file" : "lib/Mail/DMARC/Report/Receive.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Report::Send" : {
          "file" : "lib/Mail/DMARC/Report/Send.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Report::Send::HTTP" : {
          "file" : "lib/Mail/DMARC/Report/Send/HTTP.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Report::Send::SMTP" : {
          "file" : "lib/Mail/DMARC/Report/Send/SMTP.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Report::Sender" : {
          "file" : "lib/Mail/DMARC/Report/Sender.pm"
       },
       "Mail::DMARC::Report::Store" : {
          "file" : "lib/Mail/DMARC/Report/Store.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Report::Store::SQL" : {
          "file" : "lib/Mail/DMARC/Report/Store/SQL.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Report::Store::SQL::Grammars::MySQL" : {
          "file" : "lib/Mail/DMARC/Report/Store/SQL/Grammars/MySQL.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Report::Store::SQL::Grammars::PostgreSQL" : {
          "file" : "lib/Mail/DMARC/Report/Store/SQL/Grammars/PostgreSQL.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Report::Store::SQL::Grammars::SQLite" : {
          "file" : "lib/Mail/DMARC/Report/Store/SQL/Grammars/SQLite.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Report::URI" : {
          "file" : "lib/Mail/DMARC/Report/URI.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Result" : {
          "file" : "lib/Mail/DMARC/Result.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Result::Reason" : {
          "file" : "lib/Mail/DMARC/Result/Reason.pm",
-         "version" : "2.20260621"
+         "version" : "2.20260827"
       },
       "Mail::DMARC::Test::Transport" : {
          "file" : "lib/Mail/DMARC/Test/Transport.pm"
@@ -204,7 +204,7 @@
          "url" : "https://github.com/msimerson/mail-dmarc"
       }
    },
-   "version" : "2.20260621",
+   "version" : "2.20260827",
    "x_contributors" : [
       "Benny Pedersen <me@junc.eu>",
       "Jean Paul Galea <jeanpaul@yubico.com>",
@@ -212,5 +212,5 @@
       "Priyadi Iman Nurcahyo <priyadi@priyadi.net>",
       "Ricardo Signes <rjbs@cpan.org>"
    ],
-   "x_serialization_backend" : "JSON::PP version 4.06"
+   "x_serialization_backend" : "JSON::PP version 4.16"
 }

--- a/META.yml
+++ b/META.yml
@@ -15,7 +15,7 @@ configure_requires:
   File::ShareDir::Install: '0.06'
   Module::Build: '0.3601'
 dynamic_config: 1
-generated_by: 'Module::Build version 0.4234, CPAN::Meta::Converter version 2.150013'
+generated_by: 'Module::Build version 0.4234, CPAN::Meta::Converter version 2.150010'
 license: perl
 meta-spec:
   url: http://module-build.sourceforge.net/META-spec-v1.4.html
@@ -24,87 +24,87 @@ name: Mail-DMARC
 provides:
   Mail::DMARC:
     file: lib/Mail/DMARC.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Base:
     file: lib/Mail/DMARC/Base.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::HTTP:
     file: lib/Mail/DMARC/HTTP.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Policy:
     file: lib/Mail/DMARC/Policy.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::PurePerl:
     file: lib/Mail/DMARC/PurePerl.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Report:
     file: lib/Mail/DMARC/Report.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Report::Aggregate:
     file: lib/Mail/DMARC/Report/Aggregate.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Report::Aggregate::Metadata:
     file: lib/Mail/DMARC/Report/Aggregate/Metadata.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Report::Aggregate::Record:
     file: lib/Mail/DMARC/Report/Aggregate/Record.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Report::Aggregate::Record::Auth_Results:
     file: lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Report::Aggregate::Record::Auth_Results::DKIM:
     file: lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/DKIM.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Report::Aggregate::Record::Auth_Results::SPF:
     file: lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/SPF.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Report::Aggregate::Record::Identifiers:
     file: lib/Mail/DMARC/Report/Aggregate/Record/Identifiers.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Report::Aggregate::Record::Row:
     file: lib/Mail/DMARC/Report/Aggregate/Record/Row.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Report::Aggregate::Record::Row::Policy_Evaluated:
     file: lib/Mail/DMARC/Report/Aggregate/Record/Row/Policy_Evaluated.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Report::Receive:
     file: lib/Mail/DMARC/Report/Receive.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Report::Send:
     file: lib/Mail/DMARC/Report/Send.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Report::Send::HTTP:
     file: lib/Mail/DMARC/Report/Send/HTTP.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Report::Send::SMTP:
     file: lib/Mail/DMARC/Report/Send/SMTP.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Report::Sender:
     file: lib/Mail/DMARC/Report/Sender.pm
   Mail::DMARC::Report::Store:
     file: lib/Mail/DMARC/Report/Store.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Report::Store::SQL:
     file: lib/Mail/DMARC/Report/Store/SQL.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Report::Store::SQL::Grammars::MySQL:
     file: lib/Mail/DMARC/Report/Store/SQL/Grammars/MySQL.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Report::Store::SQL::Grammars::PostgreSQL:
     file: lib/Mail/DMARC/Report/Store/SQL/Grammars/PostgreSQL.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Report::Store::SQL::Grammars::SQLite:
     file: lib/Mail/DMARC/Report/Store/SQL/Grammars/SQLite.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Report::URI:
     file: lib/Mail/DMARC/Report/URI.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Result:
     file: lib/Mail/DMARC/Result.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Result::Reason:
     file: lib/Mail/DMARC/Result/Reason.pm
-    version: '2.20260621'
+    version: '2.20260827'
   Mail::DMARC::Test::Transport:
     file: lib/Mail/DMARC/Test/Transport.pm
 recommends:
@@ -146,11 +146,11 @@ resources:
   homepage: https://github.com/msimerson/mail-dmarc/wiki
   license: http://dev.perl.org/licenses/
   repository: https://github.com/msimerson/mail-dmarc
-version: '2.20260621'
+version: '2.20260827'
 x_contributors:
   - 'Benny Pedersen <me@junc.eu>'
   - 'Jean Paul Galea <jeanpaul@yubico.com>'
   - 'Marisa Clardy <marisa@clardy.eu>'
   - 'Priyadi Iman Nurcahyo <priyadi@priyadi.net>'
   - 'Ricardo Signes <rjbs@cpan.org>'
-x_serialization_backend: 'CPAN::Meta::YAML version 0.020'
+x_serialization_backend: 'CPAN::Meta::YAML version 0.018'

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Mail::DMARC - Perl implementation of DMARC
 
 # VERSION
 
-version 2.20260724
+version 2.20260827
 
 # SYNOPSIS
 

--- a/lib/Mail/DMARC.pm
+++ b/lib/Mail/DMARC.pm
@@ -4,7 +4,7 @@ use warnings;
 use feature 'signatures';
 no warnings 'experimental::args_array_with_signatures';    ## no critic (ProhibitNoWarnings)
 
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 
 use Carp;
 our $psl_loads = 0;
@@ -308,7 +308,7 @@ Mail::DMARC - Perl implementation of DMARC
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 SYNOPSIS
 

--- a/lib/Mail/DMARC/Base.pm
+++ b/lib/Mail/DMARC/Base.pm
@@ -4,7 +4,7 @@ use warnings;
 use feature 'signatures';
 no warnings 'experimental::args_array_with_signatures';    ## no critic (ProhibitNoWarnings)
 
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 
 use Carp;
 use Config::Tiny;
@@ -341,7 +341,7 @@ Mail::DMARC::Base - DMARC utility functions
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 METHODS
 

--- a/lib/Mail/DMARC/HTTP.pm
+++ b/lib/Mail/DMARC/HTTP.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::HTTP;
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -378,7 +378,7 @@ Mail::DMARC::HTTP - view stored reports via HTTP
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 SYNOPSIS
 

--- a/lib/Mail/DMARC/Policy.pm
+++ b/lib/Mail/DMARC/Policy.pm
@@ -4,7 +4,7 @@ use warnings;
 use feature 'signatures';
 no warnings 'experimental::args_array_with_signatures';    ## no critic (ProhibitNoWarnings)
 
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 
 use Carp;
 
@@ -240,7 +240,7 @@ Mail::DMARC::Policy - a DMARC policy in object format
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 SYNOPSIS
 

--- a/lib/Mail/DMARC/PurePerl.pm
+++ b/lib/Mail/DMARC/PurePerl.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::PurePerl;
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -772,7 +772,7 @@ Mail::DMARC::PurePerl - Pure Perl implementation of DMARC
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 METHODS
 

--- a/lib/Mail/DMARC/Report.pm
+++ b/lib/Mail/DMARC/Report.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use feature 'signatures';
 
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 
 use Carp;
 use IO::Compress::Gzip;
@@ -82,7 +82,7 @@ Mail::DMARC::Report - A DMARC report interface
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 DESCRIPTION
 

--- a/lib/Mail/DMARC/Report/Aggregate.pm
+++ b/lib/Mail/DMARC/Report/Aggregate.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use feature 'signatures';
 
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 
 use Carp;
 use Data::Dumper;
@@ -196,7 +196,7 @@ Mail::DMARC::Report::Aggregate - aggregate report object
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 DESCRIPTION
 

--- a/lib/Mail/DMARC/Report/Aggregate/Metadata.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Metadata.pm
@@ -4,7 +4,7 @@ use warnings;
 use feature 'signatures';
 no warnings 'experimental::args_array_with_signatures';    ## no critic (ProhibitNoWarnings)
 
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 
 use XML::LibXML;
 
@@ -98,7 +98,7 @@ Mail::DMARC::Report::Aggregate::Metadata - metadata section of aggregate report
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 AUTHORS
 

--- a/lib/Mail/DMARC/Report/Aggregate/Record.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Aggregate::Record;
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -78,7 +78,7 @@ Mail::DMARC::Report::Aggregate::Record - record section of aggregate report
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 DESCRIPTION
 

--- a/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Aggregate::Record::Auth_Results;
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -81,7 +81,7 @@ Mail::DMARC::Report::Aggregate::Record::Auth_Results - auth_results section of a
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 AUTHORS
 

--- a/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/DKIM.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/DKIM.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Aggregate::Record::Auth_Results::DKIM;
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -85,7 +85,7 @@ Mail::DMARC::Report::Aggregate::Record::Auth_Results::DKIM - auth_results/dkim s
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 AUTHORS
 

--- a/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/SPF.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Auth_Results/SPF.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Aggregate::Record::Auth_Results::SPF;
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -93,7 +93,7 @@ Mail::DMARC::Report::Aggregate::Record::Auth_Results::SPF - auth_results/spf sec
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 AUTHORS
 

--- a/lib/Mail/DMARC/Report/Aggregate/Record/Identifiers.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Identifiers.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Aggregate::Record::Identifiers;
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -44,7 +44,7 @@ Mail::DMARC::Report::Aggregate::Record::Identifiers - identifiers section of a D
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 AUTHORS
 

--- a/lib/Mail/DMARC/Report/Aggregate/Record/Row.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Row.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Aggregate::Record::Row;
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -56,7 +56,7 @@ Mail::DMARC::Report::Aggregate::Record::Row - row section of a DMARC aggregate r
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 AUTHORS
 

--- a/lib/Mail/DMARC/Report/Aggregate/Record/Row/Policy_Evaluated.pm
+++ b/lib/Mail/DMARC/Report/Aggregate/Record/Row/Policy_Evaluated.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Aggregate::Record::Row::Policy_Evaluated;
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -57,7 +57,7 @@ Mail::DMARC::Report::Aggregate::Record::Row::Policy_Evaluated - row/policy_evalu
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 AUTHORS
 

--- a/lib/Mail/DMARC/Report/Receive.pm
+++ b/lib/Mail/DMARC/Report/Receive.pm
@@ -5,7 +5,7 @@ use feature 'signatures';
 use feature 'try';
 no warnings 'experimental::try';    ## no critic (ProhibitNoWarnings)
 
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 
 use Carp;
 use Data::Dumper;
@@ -482,7 +482,7 @@ Mail::DMARC::Report::Receive - process incoming DMARC reports
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 DESCRIPTION
 

--- a/lib/Mail/DMARC/Report/Send.pm
+++ b/lib/Mail/DMARC/Report/Send.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use feature 'signatures';
 
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 
 use parent 'Mail::DMARC::Base';
 
@@ -60,7 +60,7 @@ Mail::DMARC::Report::Send - report sending dispatch class
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 DESCRIPTION
 

--- a/lib/Mail/DMARC/Report/Send/HTTP.pm
+++ b/lib/Mail/DMARC/Report/Send/HTTP.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use feature 'signatures';
 
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 
 use Carp;
 
@@ -53,7 +53,7 @@ Mail::DMARC::Report::Send::HTTP - utility methods to send reports by HTTP
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 12.2.2. HTTP
 

--- a/lib/Mail/DMARC/Report/Send/SMTP.pm
+++ b/lib/Mail/DMARC/Report/Send/SMTP.pm
@@ -5,7 +5,7 @@ use feature 'signatures';
 use feature 'try';
 no warnings 'experimental::try';    ## no critic (ProhibitNoWarnings)
 
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 
 use Carp;
 use Email::MIME;
@@ -217,7 +217,7 @@ Mail::DMARC::Report::Send::SMTP - utility methods for sending reports via SMTP
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head2 SUBJECT FIELD
 

--- a/lib/Mail/DMARC/Report/Store.pm
+++ b/lib/Mail/DMARC/Report/Store.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Store;
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -60,7 +60,7 @@ Mail::DMARC::Report::Store - persistent storage broker for reports
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 SYNOPSIS
 

--- a/lib/Mail/DMARC/Report/Store/SQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Store::SQL;
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -1052,7 +1052,7 @@ Mail::DMARC::Report::Store::SQL - store and retrieve reports from a SQL RDBMS
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 DESCRIPTION
 

--- a/lib/Mail/DMARC/Report/Store/SQL/Grammars/MySQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL/Grammars/MySQL.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Store::SQL::Grammars::MySQL;
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -467,7 +467,7 @@ Mail::DMARC::Report::Store::SQL::Grammars::MySQL - Grammar for working with mysq
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 SYPNOSIS
 

--- a/lib/Mail/DMARC/Report/Store/SQL/Grammars/PostgreSQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL/Grammars/PostgreSQL.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Store::SQL::Grammars::PostgreSQL;
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -490,7 +490,7 @@ Mail::DMARC::Report::Store::SQL::Grammars::PostgreSQL - Grammar for working with
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 SYPNOSIS
 

--- a/lib/Mail/DMARC/Report/Store/SQL/Grammars/SQLite.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL/Grammars/SQLite.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Store::SQL::Grammars::SQLite;
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -467,7 +467,7 @@ Mail::DMARC::Report::Store::SQL::Grammars::SQLite - Grammar for working with sql
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 SYPNOSIS
 

--- a/lib/Mail/DMARC/Report/URI.pm
+++ b/lib/Mail/DMARC/Report/URI.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use feature 'signatures';
 
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 
 use Carp;
 use URI;
@@ -68,7 +68,7 @@ Mail::DMARC::Report::URI - a DMARC report URI
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 SYNOPSIS
 

--- a/lib/Mail/DMARC/Result.pm
+++ b/lib/Mail/DMARC/Result.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Result;
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -94,7 +94,7 @@ Mail::DMARC::Result - an aggregate report result object
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 OVERVIEW
 

--- a/lib/Mail/DMARC/Result/Reason.pm
+++ b/lib/Mail/DMARC/Result/Reason.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Result::Reason;
-our $VERSION = '2.20260724';
+our $VERSION = '2.20260827';
 use strict;
 use warnings;
 use feature 'signatures';
@@ -46,7 +46,7 @@ Mail::DMARC::Result::Reason - policy override reason
 
 =head1 VERSION
 
-version 2.20260724
+version 2.20260827
 
 =head1 METHODS
 

--- a/share/public_suffix_list
+++ b/share/public_suffix_list
@@ -5,8 +5,8 @@
 // Please pull this list from, and only from https://publicsuffix.org/list/public_suffix_list.dat,
 // rather than any other VCS sites. Pulling from any other URL is not guaranteed to be supported.
 
-// VERSION: 2026-07-23_18-24-27_UTC
-// COMMIT: 93b4eb174b2da9ee3f6effc363b579a96a65c93a
+// VERSION: 2026-08-19_19-18-48_UTC
+// COMMIT: e8c9a2b2b2856b6449999dd0ec0d118f364ed0cd
 
 // Instructions on pulling and using this list can be found at https://publicsuffix.org/list/.
 
@@ -6838,7 +6838,7 @@ org.zw
 
 // newGTLDs
 
-// List of new gTLDs imported from https://www.icann.org/resources/registries/gtlds/v2/gtlds.json on 2026-07-15T16:20:56Z
+// List of new gTLDs imported from https://www.icann.org/resources/registries/gtlds/v2/gtlds.json on 2026-07-24T16:40:16Z
 // This list is auto-generated, don't edit it manually.
 // aaa : American Automobile Association, Inc.
 // https://www.iana.org/domains/root/db/aaa.html
@@ -10732,6 +10732,10 @@ weather
 // https://www.iana.org/domains/root/db/weatherchannel.html
 weatherchannel
 
+// web : VeriSign, Inc.
+// https://www.iana.org/domains/root/db/web.html
+web
+
 // webcam : dot Webcam Limited
 // https://www.iana.org/domains/root/db/webcam.html
 webcam
@@ -11300,17 +11304,9 @@ ltd.ua
 a2hosted.com
 cpserver.com
 
-// Acorn Labs : https://acorn.io
-// Submitted by Craig Jellick <domains@acorn.io>
-*.on-acorn.io
-
 // ActiveTrail : https://www.activetrail.biz/
 // Submitted by Ofer Kalaora <postmaster@activetrail.com>
 activetrail.biz
-
-// Adaptable.io : https://adaptable.io
-// Submitted by Mark Terrel <support@adaptable.io>
-adaptable.app
 
 // addr.tools : https://addr.tools/
 // Submitted by Brian Shea <publicsuffixlist@addr.tools>
@@ -11351,7 +11347,7 @@ beep.pl
 // Aiven : https://aiven.io/
 // Submitted by Aiven Security Team <security+appdomains@aiven.io>
 aiven.app
-aivencloud.com
+*.aivencloud.com
 
 // Akamai : https://www.akamai.com/
 // Submitted by Akamai Team <publicsuffixlist@akamai.com>
@@ -12361,6 +12357,12 @@ antagonist.cloud
 // Anthropic : https://www.anthropic.com/
 // Submitted by Sid Bidasaria <security@anthropic.com>
 claude.app
+claudeusercontent.com
+frame.claudeusercontent.com
+
+// Anysphere Inc : https://cursor.com
+// Submitted by Benson Liu <security@cursor.com>
+*.cursorusercontent.com
 
 // Apigee : https://apigee.com/
 // Submitted by Apigee Security Team <security@apigee.com>
@@ -12770,6 +12772,11 @@ store.cv
 // Codeberg e. V. : https://codeberg.org
 // Submitted by Moritz Marquardt <git@momar.de>
 codeberg.page
+
+// CodePen : https://codepen.io
+// Submitted by Stephen Shaw <support@codepen.io>
+codepen.app
+codepen.dev
 
 // CodeSandbox B.V. : https://codesandbox.io
 // Submitted by Ives van Hoorne <abuse@codesandbox.io>
@@ -14026,6 +14033,10 @@ onhercules.app
 hercules-app.com
 hercules-dev.com
 
+// here.now : https://here.now/
+// Submitted by Adam Ludwin <hello@here.now>
+here.now
+
 // Heroku : https://www.heroku.com/
 // Submitted by Shumon Huque <public-dns@salesforce.com>
 herokuapp.com
@@ -14206,7 +14217,8 @@ botdash.xyz
 
 // IONOS SE : https://www.ionos.com/
 // IONOS Group SE : https://www.ionos-group.com/
-// Submitted by Henrik Willert <security@ionos.com>
+// Submitted by Anton Mehlmann <security@ionos.com>
+online-server.cloud
 apps-1and1.com
 live-website.com
 webspace-host.com
@@ -15629,6 +15641,9 @@ scbl.pl-waw.scw.cloud
 scalebook.scw.cloud
 smartlabeling.scw.cloud
 dedibox.fr
+scw.site
+ams.scw.site
+waw.scw.site
 
 // schokokeks.org GbR : https://schokokeks.org/
 // Submitted by Hanno Böck <hanno@schokokeks.org>
@@ -16267,9 +16282,9 @@ wmflabs.org
 
 // William Harrison : https://wharrison.com.au
 // Submitted by William Harrison <security@hrsn.net>
-vps.hrsn.au
 hrsn.dev
 is-a.dev
+vps.hrsn.net
 localcert.net
 
 // Windsurf : https://windsurf.com


### PR DESCRIPTION
- feat(dmarc_httpd): post_max setting, defaults to 10MB
- perf: lazy load the reporting stack, 40% faster startup
- chore(deps): drop Regexp::Common, CGI
- chore(deps): drop Socket6, Net::IP, LWP, Net::SSLeay, Net::SMTPS, CPAN
- chore(deps): optional IO::Socket::SSL for imap_fetch
- fix(Build.PL): smtp_sending, imap_fetch missing requires
- feat(dmarc_httpd): rebuild the viewer, drop jquery and DataTables
- feat(dmarc_httpd): add overview, sources and reports views
- feat(store): aggregate queries for volume, alignment and sources
- fix(dmarc_httpd): reject path traversal in serve_file
- perf(store): index report.begin and report_record.source_ip
- fix(sender): try a smart host on 25, 587, then cleartext
- fix(sender): try every MX encrypted, then in the clear
- fix(sender): never offer credentials over opportunistic TLS
- fix(sender): stop the ladder when the report alarm fires
- fix(sender): retire reports failing with non-Failure errors
- fix(sender): keep only the smart host route that worked
- fix(sender): record send errors from every route tried
- feat(sender): add smtp.smartport and smtp.smartssl
- doc(dmarc_send_reports): document smart host routing
- chore: require Email::Sender::Simple 2.000
- feat(dmarc_httpd): opt-in reverse DNS hostnames beneath source IPs #309
